### PR TITLE
First pass at HTMLBook XML Schema

### DIFF
--- a/htmlbook.xsd
+++ b/htmlbook.xsd
@@ -94,6 +94,7 @@
 <!-- Heading elements -->
 <!-- ToDo: Mixed content model that supports inlines -->
 <!-- ToDo: Support hgroup to facilitate subtitles? -->
+<!-- ToDo: Should we really require class="title" on all section heading titles? -->
 <xs:element name="h1" type="xs:token"/>
 
 <xs:element name="h2" type="xs:token"/>

--- a/mappings.asciidoc
+++ b/mappings.asciidoc
@@ -146,18 +146,18 @@ A list of mappings is below. Special semantics, unless otherwise noted, come fro
 
 *Legacy DB element*: <part>
 
-*New HTML element*: <section>
+*New HTML element*: <div>
 
 *Special semantics*: +class="part"+ 
 
 *Example*
 
 ----
-<section class="part">
+<div class="part">
   <!-- h1 used for all part titles -->
   <h1 class="title">Part Title</h1>
   <!-- Lots of part content here -->
-</section>
+</div>
 ----
 
 ==== Dedication


### PR DESCRIPTION
Hi all,

There's still additional work to be done to further flesh out content-model requirements for standard HTML5 block elements, but the scaffolding is now in place for book divisions and sections, so I think we can start validating against it.

Couple notes:
- This wasn't explicitly in our specs, but I've put in the requirement that HTML content must be namespaced, i.e.:

```
<html xmlns="http://www.w3.org/1999/xhtml">
```

Which seems like good practice, especially considering we'll be supporting MathML embedding, and potentially SVG as well.
- Per discussions with Adam earlier, I've switched the element used to mark up Parts from <section> to <div>, given restrictions imposed by XML Schema's Unique Particle Attribution Constraint, which does not permit two sibling elements with the same name to have different content models (as Parts and Chapters do). So this wouldn't work:

``` html
<body>
 <section class="chapter">
 ...
 </section>
 <section class="part">
 ...
 </section>
 <section class="part">
 ...
 </section>
</body>
```

But this is fine:

``` html
<body>
 <section class="chapter">
 ...
 </section>
 <div class="part">
 ...
 </div>
 <div class="part">
 ...
 </div>
</body>
```

Here is how you validate against the schema using xmllint:

```
$ xmllint --noout --schema htmlbook.xsd your_filename_here.html
```

I'll be continuing to iterate on this schema throughout the week and will keep you posted. Please send any feedback my way :)

Sanders
