### PR TITLE
Handling for miscellaneous elements

### DIFF
--- a/htmlbook.xsd
+++ b/htmlbook.xsd
@@ -966,7 +966,35 @@
   </xs:complexType>
 </xs:element>
   
-<xs:element name="track"/>
+<xs:element name="track">
+  <xs:complexType>
+    <xs:complexContent>
+      <xs:extension base="empty_elem_global_attrs">
+        <xs:attribute name="default">
+          <xs:simpleType>
+            <xs:restriction base="xs:token">
+              <xs:pattern value="([Dd][Ee][Ff][Aa][Uu][Ll][Tt])?"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="kind">
+          <xs:simpleType>
+            <xs:restriction base="xs:token">
+              <xs:enumeration value="captions"/>
+              <xs:enumeration value="chapters"/>
+              <xs:enumeration value="descriptions"/>
+              <xs:enumeration value="metadata"/>
+              <xs:enumeration value="subtitles"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="label" type="xs:string"/>
+        <xs:attribute name="src" type="xs:anyURI"/>
+        <xs:attribute name="srclang" type="xs:language"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
   
 <!-- ToDo: Separate out elements that can be either inline or block into a distinct list -->
 

--- a/samples/test_schema.html
+++ b/samples/test_schema.html
@@ -184,7 +184,7 @@
               <source src="test.mov" id="audio_source"/>
               <source src="test2.mov"/>
               <source src="test3.mpg"/>
-              <track></track>
+              <track id="a_track" label="ljsfksfj" default="default" kind="captions" src="http://oreilly.com" srclang="en"/>
             </audio>
             
             <video id="video" src="movie.mp4">


### PR DESCRIPTION
This pull request adds content models for the remaining miscellaneous HTML5 elements (those used in special contexts that are more specific than just "block" or "inline")
