### PR TITLE
Support for adding <math> or <svg> elements in inline contexts whenever possible

### DIFF
--- a/schema/htmlbook.xsd
+++ b/schema/htmlbook.xsd
@@ -595,7 +595,7 @@
 <xs:element name="bdo">
   <xs:complexType  mixed="true">
     <xs:sequence>
-      <xs:group ref="inlineelements" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:group ref="inlines_plus_mml_and_svg" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
     <!-- Adding the dir attribute here instead of specifying it in the "globals" attribute group
          to modify to include use="required" --> 
@@ -782,6 +782,8 @@
         <xs:element ref="u"/>
         <xs:element ref="var"/>
         <xs:element ref="wbr"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="svg:svg"/>
       </xs:choice>
       <xs:attributeGroup ref="globals"/>
   </xs:complexType>
@@ -976,6 +978,8 @@
         <xs:element ref="u"/>
         <xs:element ref="var"/>
         <xs:element ref="wbr"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="svg:svg"/>
       </xs:choice>
       <xs:attribute name="for" type="xs:IDREF"/>
       <xs:attribute name="form" type="xs:IDREF"/>
@@ -1030,6 +1034,8 @@
         <xs:element ref="u"/>
         <xs:element ref="var"/>
         <xs:element ref="wbr"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="svg:svg"/>
       </xs:choice>
       <xs:attribute name="form" type="xs:IDREF"/>
       <xs:attribute name="high" type="xs:float"/>
@@ -1100,6 +1106,8 @@
       <xs:element ref="u"/>
       <xs:element ref="var"/>
       <xs:element ref="wbr"/>
+      <xs:element ref="mml:math"/>
+      <xs:element ref="svg:svg"/>
     </xs:choice>
     <xs:attribute name="form" type="xs:IDREF"/>
     <xs:attribute name="max" type="xs:float"/>
@@ -1250,6 +1258,8 @@
       <xs:element ref="u"/>
       <xs:element ref="var"/>
       <xs:element ref="wbr"/>
+      <xs:element ref="mml:math"/>
+      <xs:element ref="svg:svg"/>
     </xs:choice>
     <xs:attribute name="pubdate">
       <xs:simpleType>
@@ -1744,7 +1754,7 @@
 <!-- ToDo: Continue to flesh out as necessary -->
 <xs:complexType name="subheading" mixed="true">
   <xs:sequence>
-    <xs:group ref="inlineelements" minOccurs="0" maxOccurs="unbounded"/>
+    <xs:group ref="inlines_plus_mml_and_svg" minOccurs="0" maxOccurs="unbounded"/>
   </xs:sequence>
   <!-- Note: special data-type attr restrictions here -->
   <xs:attribute name="data-type" use="required" type="subheadingtype"/>
@@ -1809,7 +1819,7 @@
       <xs:element ref="p"/>
       <xs:element ref="div"/>
     </xs:choice>
-    <xs:group ref="inlineelements" minOccurs="0" maxOccurs="unbounded"/>
+    <xs:group ref="inlines_plus_mml_and_svg" minOccurs="0" maxOccurs="unbounded"/>
   </xs:choice>
   <xs:attributeGroup ref="globals"/>
 </xs:complexType>


### PR DESCRIPTION
I've added support for employing `<math>` or `<svg>` elements in inline contexts whenever possible. 

The only exceptions are situations where doing so would result in the Schema being nondeterminist. This is relevant for the small subset of elements that can accept block or inline children (like a `<li>`). In these situations, you have to choose whether to have block children or inline children, e.g. this:

``` html
<li>Bullet #1</li>
```

or:

``` html
<li><p>Bullet #1</p><p>Bullet #2</p>
```

Because `<math>` and `<svg>` can be used in both block and inline contexts, they have to be classified by default into one group or the other for use in contexts like the above. So, I've classified them by default as block elements, which seems more appropriate.
