### PR TITLE
Footnoteref handling

### DIFF
--- a/htmlbook-xsl/elements.xsl
+++ b/htmlbook-xsl/elements.xsl
@@ -183,7 +183,7 @@
 	<xsl:variable name="referenced-footnote" select="key('footnote-nodes-by-id', $referenced-footnote-id)"/>
 	<xsl:choose>
 	  <xsl:when test="count($referenced-footnote) &gt; 0">
-	    <!-- Switch the context node to that of the reference footnote -->
+	    <!-- Switch the context node to that of the referenced footnote -->
 	    <xsl:for-each select="$referenced-footnote[1]">
 	      <!-- Same general handling as regular footnote markers, except footnoterefs don't get ids -->
 	      <a data-type="noteref">


### PR DESCRIPTION
Added "footnoteref" handling to htmlbook-xsl. Footnoterefs are used when you want to have two footnote markers in the body text pointing to the same footnote (one of the markers is formatted as a "footnoteref" XREF that points to the actual footnote).

Markup used is the following:

``` html
<a data-type="footnoteref" href="#id_of_footnote_being_referenced"/>
```
