### PR TITLE
Modularized TOC heading value generation to create separate toc-title template.

### DIFF
--- a/htmlbook-xsl/tocgen.xsl
+++ b/htmlbook-xsl/tocgen.xsl
@@ -68,7 +68,7 @@
 	  </xsl:attribute>
 	  <xsl:if test="$toc-include-title != 0">
 	    <h1>
-	      <xsl:value-of select="//h:body/h:h1"/>
+	      <xsl:call-template name="toc-title"/>
 	    </h1>
 	  </xsl:if>
 	  <ol>
@@ -87,6 +87,13 @@
 	</xsl:copy>
       </xsl:otherwise>
     </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="toc-title">
+    <!-- Override if you want a different value for the title heading on the TOC (e.g., the book title) -->
+    <xsl:call-template name="get-localization-value">
+      <xsl:with-param name="gentext-key" select="'tableofcontents'"/>
+    </xsl:call-template>
   </xsl:template>
 
   <func:function name="htmlbook:section-depth">


### PR DESCRIPTION
Default is to generate a heading of "Table of Contents" in whatever language is designated for the book (e.g., lang="fr") when $toc-include-title is enabled. But the toc-title template can be overridden if, for example, you want to use the book title as your TOC heading.
