### PR TITLE
Addded support for nesting <img> tags as children of <section> elements as well as Part <div>s.

### DIFF
--- a/schema/htmlbook.xsd
+++ b/schema/htmlbook.xsd
@@ -1653,7 +1653,8 @@
   <xs:sequence>
     <xs:element ref="h1"/>
     <xs:element name="h2" minOccurs="0" maxOccurs="unbounded" type="subheading"/>
-    <xs:group ref="blockelements" minOccurs="0" maxOccurs="unbounded"/>
+    <!-- Allow full set of block elements plus img elements in chapter-level sections -->
+    <xs:group ref="figure_elements" minOccurs="0" maxOccurs="unbounded"/>
     <xs:element name="section" minOccurs="0" maxOccurs="unbounded" type="sect1"/>
   </xs:sequence>
   <!-- Note: special data-type attr restrictions here -->
@@ -1666,7 +1667,8 @@
   <xs:sequence>
     <xs:element ref="h1"/>
     <xs:element name="h2" minOccurs="0" maxOccurs="unbounded" type="subheading"/>
-    <xs:group ref="blockelements" minOccurs="0" maxOccurs="unbounded"/>
+    <!-- Allow full set of block elements plus img elements in part divs -->
+    <xs:group ref="figure_elements" minOccurs="0" maxOccurs="unbounded"/>
     <xs:element name="section" maxOccurs="unbounded" type="bookmaindiv"/>
   </xs:sequence>
   <!-- Note: special data-type attr restrictions here -->
@@ -1679,7 +1681,8 @@
   <xs:sequence>
     <xs:element ref="h1"/>
     <xs:element name="h2" minOccurs="0" maxOccurs="unbounded" type="subheading"/>
-    <xs:group ref="blockelements" minOccurs="0" maxOccurs="unbounded"/>
+    <!-- Allow full set of block elements plus img elements in sect1s -->
+    <xs:group ref="figure_elements" minOccurs="0" maxOccurs="unbounded"/>
     <xs:element name="section" minOccurs="0" maxOccurs="unbounded" type="sect2"/>
   </xs:sequence>
   <!-- Note: special data-type attr restrictions here -->
@@ -1692,7 +1695,8 @@
   <xs:sequence>
     <xs:element ref="h2"/>
     <xs:element name="h3" minOccurs="0" maxOccurs="unbounded" type="subheading"/>
-    <xs:group ref="blockelements" minOccurs="0" maxOccurs="unbounded"/>
+    <!-- Allow full set of block elements plus img elements in sect2s -->
+    <xs:group ref="figure_elements" minOccurs="0" maxOccurs="unbounded"/>
     <xs:element name="section" minOccurs="0" maxOccurs="unbounded" type="sect3"/>
   </xs:sequence>
   <!-- Note: special data-type attr restrictions here -->
@@ -1705,7 +1709,8 @@
   <xs:sequence>
     <xs:element ref="h3"/>
     <xs:element name="h4" minOccurs="0" maxOccurs="unbounded" type="subheading"/>
-    <xs:group ref="blockelements" minOccurs="0" maxOccurs="unbounded"/>
+    <!-- Allow full set of block elements plus img elements in sect3s -->
+    <xs:group ref="figure_elements" minOccurs="0" maxOccurs="unbounded"/>
     <xs:element name="section" minOccurs="0" maxOccurs="unbounded" type="sect4"/>
   </xs:sequence>
   <!-- Note: special data-type attr restrictions here -->
@@ -1718,7 +1723,8 @@
   <xs:sequence>
     <xs:element ref="h4"/>
     <xs:element name="h5" minOccurs="0" maxOccurs="unbounded" type="subheading"/>
-    <xs:group ref="blockelements" minOccurs="0" maxOccurs="unbounded"/>
+    <!-- Allow full set of block elements plus img elements in sect4s -->
+    <xs:group ref="figure_elements" minOccurs="0" maxOccurs="unbounded"/>
     <xs:element name="section" minOccurs="0" maxOccurs="unbounded" type="sect5"/>
   </xs:sequence>
   <!-- Note: special data-type attr restrictions here -->
@@ -1731,7 +1737,8 @@
   <xs:sequence>
     <xs:element ref="h5"/>
     <xs:element name="h6" minOccurs="0" maxOccurs="unbounded" type="subheading"/>
-    <xs:group ref="blockelements" minOccurs="0" maxOccurs="unbounded"/>
+    <!-- Allow full set of block elements plus img elements in sect5s -->
+    <xs:group ref="figure_elements" minOccurs="0" maxOccurs="unbounded"/>
   </xs:sequence>
   <!-- Note: special data-type attr restrictions here -->
   <xs:attribute name="data-type" use="required" fixed="sect5"/>


### PR DESCRIPTION
@adamwitwer, @nelliemckesson,

Per our discussions on Monday, I've updated the Schema such that it is valid HTMLBook to nest `<img>` tags directly as children of sectioning elements. So it's now fine to do the following:

``` html
<section data-type="sect1">
  <h1>Pet photos</h1>
  <p>Here is a picture of my cat:</p>
  <img src="kitty_yarn.jpg"/>
</section>
```

The above can be used for all informal figures. For formal figures, as we discussed, you can put a caption at either the beginning or end. This is fine:

``` html
<figure>
  <figcaption>Picture of my cat</figcaption>
  <img src="kitty_yarn.jpg"/>
</figure>
```

And so is this:

``` html
<figure>
  <img src="kitty_yarn.jpg"/>
  <figcaption>Picture of my cat</figcaption>
</figure>
```
