### PR TITLE
Added $custom.chunk.wrapper param that lets you specify a custom chunk wrapper

### DIFF
--- a/htmlbook-xsl/chunk.xsl
+++ b/htmlbook-xsl/chunk.xsl
@@ -51,6 +51,10 @@ sect5:s
   <!-- By default for chunked output, turn on footnote processing into separate marker/hyperlink and footnote content -->
   <xsl:param name="process.footnotes" select="1"/>
 
+  <!-- Specify filename containing a custom "wrapper" for chunked content (expectation is that it will contain <html>, <head>, and <body> elements -->
+  <!-- Use the PI <?yield?> in the location in which the HTML chunk content should be inserted -->
+  <xsl:param name="custom.chunk.wrapper"/>
+
   <xsl:template match="/h:html">
     <xsl:apply-templates select="h:body"/>
   </xsl:template>
@@ -134,6 +138,23 @@ sect5:s
     <xsl:value-of select="$full-output-filename"/>
   </xsl:template>
 
+  <xsl:template match="@*|node()" mode="process-chunk-wrapper">
+    <xsl:param name="chunk.content"/>
+    <!-- Copy to output everything in chunk wrapper that is not the <?yield?> PI -->
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()" mode="process-chunk-wrapper">
+	<xsl:with-param name="chunk.content" select="$chunk.content"/>
+      </xsl:apply-templates>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="processing-instruction('yield')" mode="process-chunk-wrapper">
+    <xsl:param name="chunk.content"/>
+    <!-- This is our <?yield?> PI, which is the chunk content placeholder -->
+    <!-- Drop the content in here -->
+    <xsl:copy-of select="exsl:node-set($chunk.content)"/>
+  </xsl:template>
+
   <xsl:template name="write-chunk">
     <xsl:param name="output-filename"/>
     <xsl:variable name="full-output-filename">
@@ -145,6 +166,17 @@ sect5:s
       <xsl:value-of select="'&lt;!DOCTYPE html&gt;'" disable-output-escaping="yes"/>
       <!-- Only add the <html>/<head> if they don't already exist -->
       <xsl:choose>
+	<!-- If there's a custom chunk wrapper, use that to wrap the output HTML -->
+	<xsl:when test="$custom.chunk.wrapper != ''">
+	  <xsl:variable name="chunk.content">
+	    <xsl:apply-imports/>
+	  </xsl:variable>
+	  <xsl:variable name="chunk.wrapper" select="document($custom.chunk.wrapper)"/>
+	  <xsl:apply-templates select="exsl:node-set($chunk.wrapper)" mode="process-chunk-wrapper">
+	    <xsl:with-param name="chunk.content" select="$chunk.content"/>
+	  </xsl:apply-templates>
+	</xsl:when>
+	<!-- Otherwise, go ahead and do the following default chunk processing -->
 	<xsl:when test="not(self::h:html)">
 	  <html>
 	    <!-- ToDo: What else do we want in the <head>? -->


### PR DESCRIPTION
Added $custom.chunk.wrapper param that lets you specify a filename for a custom chunk wrapper--i.e, `<head>`, header, footer content that you want around each chunk of content.
