### PR TITLE
Updated book title requirements in XML Schema and corresponding XSL handling for EPUB

### DIFF
--- a/htmlbook-xsl/epub.xsl
+++ b/htmlbook-xsl/epub.xsl
@@ -61,7 +61,8 @@
   <xsl:param name="outputdir" select="'OEBPS'"/>
 
   <xsl:param name="metadata.title">
-    <xsl:value-of select="//h:body/h:h1[1]"/>
+    <!-- Look for title first in head, then as child of body -->
+    <xsl:value-of select="(//h:head/h:title|//h:body/h:h1)[1]"/>
   </xsl:param>
 
   <xsl:param name="metadata.language">

--- a/htmlbook-xsl/ncx.xsl
+++ b/htmlbook-xsl/ncx.xsl
@@ -48,7 +48,8 @@
 		</xsl:attribute>
 		<navLabel>
 		  <text>
-		    <xsl:value-of select="//h:body/h:h1"/>
+		    <!-- Look for title first in head, then as child of body -->
+		    <xsl:value-of select="(//h:head/h:title|//h:body/h:h1)[1]"/>
 		  </text>
 		</navLabel>
 	      <content src="{$root.chunk.filename}"/>

--- a/schema/htmlbook.xsd
+++ b/schema/htmlbook.xsd
@@ -35,7 +35,7 @@
 <xs:element name="body">
   <xs:complexType>
     <xs:sequence>
-      <xs:element ref="h1"/>
+      <xs:element ref="h1" minOccurs="0"/>
       <xs:element name="h2" minOccurs="0" type="subheading"/>
       <xs:element name="figure" minOccurs="0" type="coverfigure"/>
       <xs:choice maxOccurs="unbounded">


### PR DESCRIPTION
The "title" in the `<head>` is now the canonical location where the book title should be stored. Including an `<h1>` at the beginning of the `<body>` is now optional, and HTMLBook content will validate against the schema without it. 

htmlbook-xsl logic for EPUB (to generate title for OPF and NCX) has been updated accordingly, to look for title in `<head>` first and then in heading child of `<body>`.

@adamwitwer and @nelliemckesson, let me know if anything else is needed to facilitate styling
