### PR TITLE
Handling to ensure <script> tags are not self-closing (i.e., no <script/...

### DIFF
--- a/htmlbook-xsl/chunk.xsl
+++ b/htmlbook-xsl/chunk.xsl
@@ -148,6 +148,19 @@ sect5:s
     </xsl:copy>
   </xsl:template>
 
+  <xsl:template match="h:script" mode="process-chunk-wrapper">
+    <xsl:param name="chunk.content"/>
+    <!-- Special handling to ensure <script> tags are not self-closing (i.e., no <script/>), as that causes problems in many browsers -->
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()" mode="process-chunk-wrapper">
+	<xsl:with-param name="chunk.content" select="$chunk.content"/>
+      </xsl:apply-templates>
+      <xsl:if test="not(node())">
+	<xsl:text> </xsl:text>
+      </xsl:if>
+    </xsl:copy>
+  </xsl:template>
+
   <xsl:template match="processing-instruction('yield')" mode="process-chunk-wrapper">
     <xsl:param name="chunk.content"/>
     <!-- This is our <?yield?> PI, which is the chunk content placeholder -->

--- a/htmlbook-xsl/elements.xsl
+++ b/htmlbook-xsl/elements.xsl
@@ -296,10 +296,10 @@
     </p>
   </xsl:template>
 
-  <xsl:template match="h:iframe">
+  <xsl:template match="h:iframe|h:script">
     <xsl:copy>
       <xsl:apply-templates select="@*|node()"/>
-      <!-- Don't want to allow self-closing <iframe/> tags, as many browsers don't like those -->
+      <!-- Don't want to allow self-closing <iframe/> or <script/> tags, as many browsers don't like those -->
       <xsl:if test="not(node())">
 	<xsl:text> </xsl:text>
       </xsl:if>


### PR DESCRIPTION
Handling to ensure <script> tags are not self-closing (i.e., no <script/>), as that can cause problems for browsers.
