### PR TITLE
Fixed validity error in htmlbook.html sample; subtitles must have data-type

### DIFF
--- a/samples/htmlbook.html
+++ b/samples/htmlbook.html
@@ -16,7 +16,7 @@
     <!-- body must have h1 child with book title -->
     <section data-type="titlepage" class="titlepage">
       <h1>HTMLBook Sample</h1>
-      <h2>Optional Subtitle</h2>
+      <h2 data-type="subtitle">Optional Subtitle</h2>
       <p data-type="author">O’Reilly Media</p>
     </section>
     <section data-type="copyright-page">


### PR DESCRIPTION
Fixed validity error in htmlbook.html sample; subtitles must have  corresponding data-type attribute; see #92
