### PR TITLE
Refinements to cover handling

### DIFF
--- a/htmlbook-xsl/epub.xsl
+++ b/htmlbook-xsl/epub.xsl
@@ -139,8 +139,6 @@
   <!-- ID to use to reference cover filename -->
   <xsl:param name="epub.cover.html.id" select="'cover'"/>
 
-  <xsl:param name="metadata.cover.filename" select="//h:figure[@data-type = 'cover'][1]/h:img[1]/@src"/>
-
   <xsl:param name="metadata.ibooks-specified-fonts" select="1"/>
 
   <xsl:param name="package.namespaces">
@@ -150,7 +148,9 @@
   </xsl:param>
 
   <!-- Param to specify whether or not to generate a separate HTML file for the cover -->
-  <xsl:param name="generate.cover.html" select="1"/>
+  <xsl:param name="generate.cover.html">
+    <xsl:if test="//h:figure[@data-type='cover']//h:img[@src != '']">1</xsl:if>
+  </xsl:param>
 
   <!-- Param to specify filename for cover HTML (only applicable if $generate.cover.html is enabled)-->
   <xsl:param name="cover.html.filename" select="'cover.html'"/>
@@ -221,7 +221,7 @@ UbuntuMono-Italic.otf</xsl:param>
     <xsl:if test="$generate.ncx.toc = 1">
       <xsl:call-template name="generate.ncx.toc"/>
     </xsl:if>
-    <xsl:if test="$generate.cover.html">
+    <xsl:if test="$generate.cover.html = 1">
       <xsl:call-template name="generate-cover-html"/>
     </xsl:if>
     <xsl:apply-imports/>
@@ -240,9 +240,7 @@ UbuntuMono-Italic.otf</xsl:param>
 	  </xsl:if>
 	</head>
 	<body>
-	  <div>
-	    <img src="{$metadata.cover.filename}" alt="{$metadata.title}"/>
-	  </div>
+	  <xsl:copy-of select="//h:figure[@data-type='cover'][1]"/>
 	</body>
       </html>
     </exsl:document>

--- a/htmlbook-xsl/opf.xsl
+++ b/htmlbook-xsl/opf.xsl
@@ -230,7 +230,7 @@
 	      </meta>
 	    </xsl:for-each>
 	  </xsl:if>
-	  <xsl:if test="normalize-space($metadata.cover.filename) != ''">
+	  <xsl:if test="$generate.cover.html = 1">
 	    <meta name="cover" content="{$epub.cover.image.id}"/>
 	  </xsl:if>
 	  <xsl:if test="$metadata.ibooks-specified-fonts = 1">
@@ -314,7 +314,7 @@
 	  <xsl:value-of select="$ncx.toc.id"/>
 	</xsl:attribute>
       </xsl:if>
-      <xsl:if test="$cover.in.spine = 1">
+      <xsl:if test="$cover.in.spine = 1 and $generate.cover.html = 1">
 	<itemref idref="{$epub.cover.html.id}"/>
       </xsl:if>
       <xsl:if test="$generate.root.chunk = 1">


### PR DESCRIPTION
Refinements to cover handling:
- Better default handling for the generate.cover.html param, such that it's turned on by default if there's a `<figure data-type="cover">` in the source, but otherwise turned off. 
- Ensure cover.html-generated cover content preserves markup in source `<figure data-type="cover">`.
- Remove effectively extraneous param $metadata.cover.filename
