### PR TITLE
Handling for pagebreak PI, and corresponding tests.

### DIFF
--- a/htmlbook-xsl/htmlbook.xsl
+++ b/htmlbook-xsl/htmlbook.xsl
@@ -14,6 +14,7 @@
 
   <xsl:include href="param.xsl"/> <!-- HTMLBook params -->
   <xsl:include href="elements.xsl"/> <!-- Postprocessing of elements as needed (e.g., Id decoration as needed for autogeneration of TOC/index) -->
+  <xsl:include href="pis.xsl"/> <!-- Handling for Processing Instructions -->
   <xsl:include href="tocgen.xsl"/> <!-- Autogeneration of TOC if specified in autogenerate-toc -->
   <xsl:include href="indexgen.xsl"/> <!-- Autogeneration of index if specified in autogenerate-index -->
   <xsl:include href="xrefgen.xsl"/> <!-- Autogeneration of XREFs if specified in autogenerate-xrefs -->

--- a/htmlbook-xsl/pis.xsl
+++ b/htmlbook-xsl/pis.xsl
@@ -1,0 +1,19 @@
+<xsl:stylesheet version="1.0"
+		xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+		xmlns:exsl="http://exslt.org/common"
+		xmlns:h="http://www.w3.org/1999/xhtml"
+		xmlns="http://www.w3.org/1999/xhtml"
+		extension-element-prefixes="exsl"
+		exclude-result-prefixes="exsl h">
+
+  <!-- Templates for Processing Instruction handling/functionality -->
+
+  <xsl:output method="xml"
+              encoding="UTF-8"/>
+  <xsl:preserve-space elements="*"/>
+
+  <xsl:template match="processing-instruction()[contains(name(), 'pagebreak')]"> 
+    <div class="{name()}" />
+  </xsl:template>
+
+</xsl:stylesheet> 

--- a/htmlbook-xsl/xspec/pis.xspec
+++ b/htmlbook-xsl/xspec/pis.xspec
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               xmlns:functx="http://www.functx.com"
+	       xmlns="http://www.w3.org/1999/xhtml"
+               stylesheet="../htmlbook.xsl">
+
+  <!-- Test suite for pis.xsl -->
+  
+  <!--
+      This scenario demonstrates how to test a matching template.
+    -->
+  <x:scenario label="When encountering a 'pagebreak' Processing Instruction">
+    <!-- apply template rules to this element -->
+    <x:context>
+      <?hard-pagebreak?>
+    </x:context>
+    <!-- check the result -->
+    <x:expect label="Convert it to a pagebreak 'div'">
+      <div class="hard-pagebreak"/>
+    </x:expect>
+  </x:scenario>
+</x:description>


### PR DESCRIPTION
Adding a standard handling to convert PIs that contain the word "pagebreak", e.g.:

``` xml
<?hard-pagebreak?>
```

To a div whose class is equal to the PI name, e.g.:

``` html
<div class="hard-pagebreak"/>
```

Which can then be used for pagebreaking in CSS.
