### PR TITLE
EPUB XSL parameter tweaks

### DIFF
--- a/htmlbook-xsl/epub.xsl
+++ b/htmlbook-xsl/epub.xsl
@@ -170,12 +170,15 @@
   <!-- Include labels in NCX TOC? -->
   <xsl:param name="ncx.toc.include.labels" select="1"/>
 
+  <!-- Include labels in Nav Doc TOC -->
+  <xsl:param name="toc-include-labels" select="1"/>
+
   <!-- Include root chunk (index.html) in NCX? -->
   <!-- Don't turn this parameter on if you're not generating a root chunk -->
   <xsl:param name="ncx.include.root.chunk" select="$generate.root.chunk"/>
 
   <!-- Param to specify whether or not to include the Navigation Document (XHTML5 TOC) in the spine -->
-  <xsl:param name="nav.in.spine" select="1"/>
+  <xsl:param name="nav.in.spine" select="0"/>
 
   <!-- Param to specify whether or not to include the Navigation Document (XHTML5 TOC) in the NCX TOC -->
   <xsl:param name="nav.in.ncx" select="0"/>


### PR DESCRIPTION
By default, do not include Nav Doc in EPUB spine, but do add labels to list items in it.
