### PR TITLE
Improved default handling of NCX/OPF identifiers

### DIFF
--- a/htmlbook-xsl/epub.xsl
+++ b/htmlbook-xsl/epub.xsl
@@ -49,6 +49,14 @@
     <xsl:value-of select="//h:head/h:meta[contains(@name, 'identifier')][1]/@content"/>
   </xsl:param>
 
+  <xsl:param name="computed.identifier">
+    <xsl:value-of select="$metadata.unique-identifier"/>
+    <!-- If no identifier supplied, add a default value to ensure validity -->
+    <xsl:if test="not($metadata.unique-identifier) or normalize-space($metadata.unique-identifier) = ''">
+      <xsl:value-of select="concat('randomid-', generate-id())"/>
+    </xsl:if>
+  </xsl:param>
+
   <!-- ID to use on the dc:identifier element corresponding to the EPUB unique identifier -->
   <xsl:param name="metadata.unique-identifier.id" select="'pub-identifier'"/>
 

--- a/htmlbook-xsl/ncx.xsl
+++ b/htmlbook-xsl/ncx.xsl
@@ -40,7 +40,7 @@
 	<xsl:if test="$generate.cover.html = 1">
 	  <meta name="cover" content="{$epub.cover.html.id}"/>
 	</xsl:if>
-	<meta name="dtb:uid" content="{$metadata.unique-identifier}"/>
+	<meta name="dtb:uid" content="{$computed.identifier}"/>
       </head>
       <docTitle>
 	<text>

--- a/htmlbook-xsl/opf.xsl
+++ b/htmlbook-xsl/opf.xsl
@@ -237,8 +237,8 @@
   </xsl:template>
 
   <xsl:template name="opf.metadata">
-    <xsl:param name="metadata.unique-identifier" select="$metadata.unique-identifier"/>
     <xsl:param name="metadata.unique-identifier.id" select="$metadata.unique-identifier.id"/>
+    <xsl:param name="computed.identifier" select="$computed.identifier"/>
     <xsl:param name="metadata.title" select="$metadata.title"/>
     <xsl:param name="metadata.language" select="$metadata.language"/>
     <xsl:param name="metadata.modified" select="$metadata.modified"/>
@@ -252,13 +252,6 @@
     <xsl:param name="metadata.ibooks-specified-fonts" select="$metadata.ibooks-specified-fonts"/>
     <xsl:param name="generate.cover.html" select="$generate.cover.html"/>
     <metadata>
-      <xsl:variable name="computed.identifier">
-	<xsl:value-of select="$metadata.unique-identifier"/>
-	<!-- If no identifier supplied, add a default value to ensure validity -->
-	<xsl:if test="not($metadata.unique-identifier) or normalize-space($metadata.unique-identifier) = ''">
-	  <xsl:value-of select="concat('randomid-', generate-id())"/>
-	</xsl:if>
-      </xsl:variable>
 
       <xsl:variable name="computed.title">
 	<xsl:value-of select="$metadata.title"/>

--- a/htmlbook-xsl/xspec/opf.xspec
+++ b/htmlbook-xsl/xspec/opf.xspec
@@ -15,6 +15,7 @@
 
   <!-- Global params for testing -->
   <x:param name="metadata.unique-identifier.id" select="'pub-identifier'"/>
+  <x:param name="metadata.unique-identifier"/> <!-- Leave blank globally -->
   <x:param name="metadata.ibooks-specified-fonts" select="1"/>
   <x:param name="generate.cover.html" select="1"/>
 
@@ -249,7 +250,7 @@ UbuntuMono-Regular.otf
 
   <x:scenario label="When generating OPF metadata for a book (with all metadata supplied)">
     <x:call template="opf.metadata">
-      <x:param name="metadata.unique-identifier" select="'9780000000000'"/>
+      <x:param name="computed.identifier" select="'9780000000000'"/>
       <x:param name="metadata.ibooks-specified-fonts" select="1"/>
       <x:param name="metadata.title" select="'Understanding Computation'"/>
       <x:param name="metadata.language" select="'fr'"/>
@@ -295,46 +296,6 @@ UbuntuMono-Regular.otf
     <x:expect label="Cover metadata should be generated" test="exists(/opf:metadata/opf:meta[@name='cover' and @content='bookcoverimage'])"/>
     <x:expect label="iBooks metadata should be generated if specified" test="exists(/opf:metadata/opf:meta[@property='ibooks:specified-fonts' and . = 'true'])"/>
 
-    <x:scenario label="When generating OPF metadata for book without any metadata supplied or a cover">
-      <x:call>
-	<x:param name="metadata.unique-identifier"/>
-	<x:param name="metadata.ibooks-specified-fonts"/>
-	<x:param name="metadata.title"/>
-	<x:param name="metadata.language"/>
-	<x:param name="metadata.modified"/>
-	<x:param name="metadata.rights"/>
-	<x:param name="metadata.publisher"/>
-	<x:param name="metadata.subject"/>
-	<x:param name="metadata.date"/>
-	<x:param name="metadata.description"/>
-	<x:param name="metadata.contributors"/>
-	<x:param name="metadata.creators"/>
-	<x:param name="generate.cover.html"/>
-      </x:call>
-      <x:expect label="Default value should be subbed in for book identifier to ensure EPUB validity" test="exists(/opf:metadata/dc:identifier[contains(., 'randomid')]) and
-													    exists(/opf:metadata/opf:meta[@property = 'dcterms:identifier' and contains(., 'randomid')])"/>
-      <x:expect label="Default value should be subbed in for book title to ensure EPUB validity" test="exists(/opf:metadata/dc:title[. = 'Untitled Book']) and
-												       exists(/opf:metadata/opf:meta[@property = 'dcterms:title' and . = 'Untitled Book'])"/>
-      <x:expect label="Default value should be subbed in for book language to ensure EPUB validity" test="exists(/opf:metadata/dc:language[. = 'en']) and
-													  exists(/opf:metadata/opf:meta[@property = 'dcterms:language' and . = 'en'])"/>
-      <x:expect label="Default value should be subbed in for book modification date to ensure EPUB validity" test="exists(/opf:metadata/opf:meta[@property = 'dcterms:modified' and . = '2014-01-01'])"/>
-      <x:expect label="Rights information *should not* be generated" test="not(exists(/opf:metadata/dc:rights)) and 
-									   not(exists(/opf:metadata/opf:meta[@property = 'dcterms:rightsHolder']))"/>
-      <x:expect label="Publisher information *should not* be generated" test="not(exists(/opf:metadata/dc:publisher)) and
-									      not(exists(/opf:metadata/opf:meta[@property = 'dcterms:publisher']))"/>
-      <x:expect label="Subject (category) information *should not* be generated" test="not(exists(/opf:metadata/dc:subject)) and
-										       not(exists(/opf:metadata/opf:meta[@property = 'dcterms:subject']))"/>
-      <x:expect label="Publication date information *should not* be generated" test="not(exists(/opf:metadata/dc:date)) and
-										     not(exists(/opf:metadata/opf:meta[@property = 'dcterms:date']))"/>
-      <x:expect label="Description information *should not* be generated" test="not(exists(/opf:metadata/dc:description)) and
-										not(exists(/opf:metadata/opf:meta[@property = 'dcterms:description']))"/>
-      <x:expect label="Contributor information *should not* be generated" test="not(exists(/opf:metadata/dc:contributor)) and
-										not(exists(/opf:metadata/opf:meta[@property = 'dcterms:contributor']))"/>
-      <x:expect label="Creator information *should not* be generated" test="not(exists(/opf:metadata/dc:creator)) and
-									    not(exists(/opf:metadata/opf:meta[@property = 'dcterms:creator']))"/>
-      <x:expect label="Cover metadata *should not* be generated if book does not have a cover" test="not(exists(/opf:metadata/opf:meta[@name = 'cover']))"/>
-      <x:expect label="iBooks metadata *should not* be generated if *not* specified" test="not(exists(/opf:metadata/opf:meta[@property='ibooks:specified-fonts']))"/>
-    </x:scenario>
     <x:scenario label="When generating OPF metadata for a book with two authors specified">
       <x:call>
 	<x:param name="metadata.creators">
@@ -384,6 +345,46 @@ UbuntuMono-Regular.otf
     </x:scenario>
 
   </x:scenario>
+
+    <x:scenario label="When generating OPF metadata for book without any metadata supplied or a cover">
+      <x:call template="opf.metadata">
+	<x:param name="metadata.ibooks-specified-fonts"/>
+	<x:param name="metadata.title"/>
+	<x:param name="metadata.language"/>
+	<x:param name="metadata.modified"/>
+	<x:param name="metadata.rights"/>
+	<x:param name="metadata.publisher"/>
+	<x:param name="metadata.subject"/>
+	<x:param name="metadata.date"/>
+	<x:param name="metadata.description"/>
+	<x:param name="metadata.contributors"/>
+	<x:param name="metadata.creators"/>
+	<x:param name="generate.cover.html"/>
+      </x:call>
+      <x:expect label="Default value should be subbed in for book identifier to ensure EPUB validity" test="exists(/opf:metadata/dc:identifier[contains(., 'randomid')]) and
+													    exists(/opf:metadata/opf:meta[@property = 'dcterms:identifier' and contains(., 'randomid')])"/>
+      <x:expect label="Default value should be subbed in for book title to ensure EPUB validity" test="exists(/opf:metadata/dc:title[. = 'Untitled Book']) and
+												       exists(/opf:metadata/opf:meta[@property = 'dcterms:title' and . = 'Untitled Book'])"/>
+      <x:expect label="Default value should be subbed in for book language to ensure EPUB validity" test="exists(/opf:metadata/dc:language[. = 'en']) and
+													  exists(/opf:metadata/opf:meta[@property = 'dcterms:language' and . = 'en'])"/>
+      <x:expect label="Default value should be subbed in for book modification date to ensure EPUB validity" test="exists(/opf:metadata/opf:meta[@property = 'dcterms:modified' and . = '2014-01-01'])"/>
+      <x:expect label="Rights information *should not* be generated" test="not(exists(/opf:metadata/dc:rights)) and 
+									   not(exists(/opf:metadata/opf:meta[@property = 'dcterms:rightsHolder']))"/>
+      <x:expect label="Publisher information *should not* be generated" test="not(exists(/opf:metadata/dc:publisher)) and
+									      not(exists(/opf:metadata/opf:meta[@property = 'dcterms:publisher']))"/>
+      <x:expect label="Subject (category) information *should not* be generated" test="not(exists(/opf:metadata/dc:subject)) and
+										       not(exists(/opf:metadata/opf:meta[@property = 'dcterms:subject']))"/>
+      <x:expect label="Publication date information *should not* be generated" test="not(exists(/opf:metadata/dc:date)) and
+										     not(exists(/opf:metadata/opf:meta[@property = 'dcterms:date']))"/>
+      <x:expect label="Description information *should not* be generated" test="not(exists(/opf:metadata/dc:description)) and
+										not(exists(/opf:metadata/opf:meta[@property = 'dcterms:description']))"/>
+      <x:expect label="Contributor information *should not* be generated" test="not(exists(/opf:metadata/dc:contributor)) and
+										not(exists(/opf:metadata/opf:meta[@property = 'dcterms:contributor']))"/>
+      <x:expect label="Creator information *should not* be generated" test="not(exists(/opf:metadata/dc:creator)) and
+									    not(exists(/opf:metadata/opf:meta[@property = 'dcterms:creator']))"/>
+      <x:expect label="Cover metadata *should not* be generated if book does not have a cover" test="not(exists(/opf:metadata/opf:meta[@name = 'cover']))"/>
+      <x:expect label="iBooks metadata *should not* be generated if *not* specified" test="not(exists(/opf:metadata/opf:meta[@property='ibooks:specified-fonts']))"/>
+    </x:scenario>
 
     <x:scenario label="When generate-spine is called">
       <x:call template="generate-spine">


### PR DESCRIPTION
Fixing bug where NCX dtb:uid identifier did not sync up with OPF unique-identifier when default identifier values were generated.
