### PR TITLE
Parameterized handling for "pagenum" classes for print outputs

### DIFF
--- a/htmlbook-xsl/chunk.xsl
+++ b/htmlbook-xsl/chunk.xsl
@@ -59,6 +59,9 @@ sect5:s
        links will be clickable -->
   <xsl:param name="url.in.parens" select="0"/>
 
+  <!-- Chunked output typically not used for print output, so disabling addition of "pagenum" classes on all XREFs -->
+  <xsl:param name="xref.elements.pagenum.in.class"/>
+
   <xsl:template match="/h:html">
     <xsl:apply-templates select="h:body"/>
   </xsl:template>
@@ -325,6 +328,8 @@ sect5:s
   <!-- All XREFs must be tagged with a @data-type containing XREF -->
   <xsl:template match="h:a[contains(@data-type, 'xref')]" name="process-as-xref">
     <xsl:param name="autogenerate-xrefs" select="$autogenerate-xrefs"/>
+    <xsl:param name="xref.elements.pagenum.in.class" select="$xref.elements.pagenum.in.class"/>
+
     <xsl:variable name="calculated-output-href">
       <xsl:call-template name="calculate-output-href">
 	<xsl:with-param name="source-href-value" select="@href"/>
@@ -341,6 +346,11 @@ sect5:s
       <xsl:choose>
 	<xsl:when test="(count(key('id', $href-anchor)) &gt; 0) and ($is-xref = 1)">
 	  <xsl:variable name="target" select="key('id', $href-anchor)[1]"/>
+	  <!-- If we can locate the target, reprocess class attribute to add "pagenum" class value if needed -->
+	  <xsl:apply-templates select="." mode="class.attribute">
+	    <xsl:with-param name="xref.elements.pagenum.in.class" select="$xref.elements.pagenum.in.class"/>
+	    <xsl:with-param name="xref.target" select="$target"/>
+	  </xsl:apply-templates>
 	  <!-- Regenerate the href here, to ensure it accurately points to correct location, including chunk filename) -->
 	  <xsl:attribute name="href">
 	    <xsl:call-template name="href.target">

--- a/htmlbook-xsl/common.xsl
+++ b/htmlbook-xsl/common.xsl
@@ -466,8 +466,8 @@
       </xsl:when>
       <xsl:when test="$node[self::h:aside]">
 	<xsl:choose>
-	  <xsl:when test="@data-type">
-	    <xsl:value-of select="@data-type"/>
+	  <xsl:when test="$node[@data-type]">
+	    <xsl:value-of select="$node/@data-type"/>
 	  </xsl:when>
 	  <xsl:otherwise>sidebar</xsl:otherwise>
 	</xsl:choose>
@@ -617,5 +617,67 @@
 
   <!-- Default rule for PDF bookmarks; do nothing for elements that aren't sections or Part divs -->
   <xsl:template match="*" mode="pdf-bookmark"/>
+
+  <!-- Templates for handling of class values -->
+  <xsl:template match="*" mode="class.attribute">
+    <xsl:param name="xref.elements.pagenum.in.class" select="$xref.elements.pagenum.in.class"/>
+    <xsl:param name="xref.target"/>
+    <xsl:param name="class" select="@class"/>
+    <xsl:variable name="class.value">
+      <xsl:apply-templates select="." mode="class.value">
+	<xsl:with-param name="class" select="$class"/>
+	<xsl:with-param name="xref.elements.pagenum.in.class" select="$xref.elements.pagenum.in.class"/>
+	<xsl:with-param name="xref.target" select="$xref.target"/>
+      </xsl:apply-templates>
+    </xsl:variable>
+    <xsl:if test="normalize-space($class.value) != ''">
+      <xsl:attribute name="class">
+	<xsl:value-of select="$class.value"/>
+      </xsl:attribute>
+    </xsl:if>
+  </xsl:template>
+  
+  <!-- Default is to use supplied $class param as @class value -->
+  <xsl:template match="*" mode="class.value">
+    <xsl:param name="class" select="@class"/>
+    <xsl:param name="xref.elements.pagenum.in.class" select="$xref.elements.pagenum.in.class"/>
+    <xsl:param name="xref.target"/>
+    <xsl:value-of select="$class"/>
+  </xsl:template>
+
+  <xsl:template match="h:a[@data-type='xref']" mode="class.value">
+    <xsl:param name="class" select="@class"/>
+    <xsl:param name="xref.elements.pagenum.in.class" select="$xref.elements.pagenum.in.class"/>
+    <xsl:param name="xref.target"/>
+    <xsl:choose>
+      <!-- If there's an xref target, process that to determine whether a pagenum value should be added to the class -->
+      <xsl:when test="$xref.target">
+	<xsl:variable name="xref.target.semantic.name">
+	  <xsl:call-template name="semantic-name">
+	    <xsl:with-param name="node" select="$xref.target"/>
+	  </xsl:call-template>
+	</xsl:variable>
+	<xsl:if test="$class != ''">
+	  <xsl:value-of select="$class"/>
+	</xsl:if>
+	<!-- Check if target semantic name is in list of XREF elements containing pagenum -->
+	<!-- ToDo: Consider modularizing logic into separate function if needed for reuse elsewhere -->
+	<xsl:variable name="space-delimited-pagenum-elements" select="concat(' ', normalize-space($xref.elements.pagenum.in.class), ' ')"/>
+	<xsl:variable name="substring-before-target-name" select="substring-before($space-delimited-pagenum-elements, $xref.target.semantic.name)"/>
+	<xsl:variable name="substring-after-target-name" select="substring-after($space-delimited-pagenum-elements, $xref.target.semantic.name)"/>
+	<!-- Make sure a match is both preceded and followed by a space -->
+	<xsl:if test="substring($substring-after-target-name, 1, 1) and
+		      substring($substring-before-target-name, string-length($substring-before-target-name), 1)">
+	  <xsl:if test="$class != ''"><xsl:text> </xsl:text></xsl:if>
+	  <xsl:text>pagenum</xsl:text>
+	</xsl:if>
+      </xsl:when>
+      <xsl:otherwise>
+	<xsl:if test="$class != ''">
+	  <xsl:value-of select="$class"/>
+	</xsl:if>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 
 </xsl:stylesheet> 

--- a/htmlbook-xsl/param.xsl
+++ b/htmlbook-xsl/param.xsl
@@ -160,4 +160,17 @@ sect5:xref
   <!-- When set to 1, add a <div> within a <figure> to encapsulate all the non-caption <figure> content (to facilitate styling) -->
   <xsl:param name="figure.border.div" select="0"/>
 
+  <!-- Params around page numeration -->
+
+  <!-- Add a class of "pagenum" to XREFs pointing to element in the supplied list -->
+  <!-- Element names correspond to values produced by "semantic-name" template in common.xsl -->
+  <xsl:param name="xref.elements.pagenum.in.class">
+sect1
+sect2
+sect3
+sect4
+sect5
+sidebar
+</xsl:param>
+
 </xsl:stylesheet> 

--- a/htmlbook-xsl/xrefgen.xsl
+++ b/htmlbook-xsl/xrefgen.xsl
@@ -16,6 +16,8 @@
   <!-- All XREFs must be tagged with a @data-type containing XREF -->
   <xsl:template match="h:a[contains(@data-type, 'xref')]" name="process-as-xref">
     <xsl:param name="autogenerate-xrefs" select="$autogenerate-xrefs"/>
+    <xsl:param name="xref.elements.pagenum.in.class" select="$xref.elements.pagenum.in.class"/>
+
     <xsl:variable name="calculated-output-href">
       <xsl:call-template name="calculate-output-href">
 	<xsl:with-param name="source-href-value" select="@href"/>
@@ -36,9 +38,13 @@
 	  <!-- Generate XREF text node if $autogenerate-xrefs is enabled -->
 	  <xsl:when test="($autogenerate-xrefs = 1) and ($is-xref = 1)">
 	    <xsl:choose>
-	      <!-- If we can locate the target, process gentext with "xref-to" -->
+	      <!-- If we can locate the target, reprocess class attribute to add "pagenum" if needed, and process gentext with "xref-to" -->
 	      <xsl:when test="count(key('id', $href-anchor)) > 0">
 		<xsl:variable name="target" select="key('id', $href-anchor)[1]"/>
+		<xsl:apply-templates select="." mode="class.attribute">
+		  <xsl:with-param name="xref.elements.pagenum.in.class" select="$xref.elements.pagenum.in.class"/>
+		  <xsl:with-param name="xref.target" select="$target"/>
+		</xsl:apply-templates>
 		<xsl:apply-templates select="$target" mode="xref-to">
 		  <xsl:with-param name="referrer" select="."/>
 		  <xsl:with-param name="xrefstyle" select="@data-xrefstyle"/>

--- a/htmlbook-xsl/xspec/chunk.xspec
+++ b/htmlbook-xsl/xspec/chunk.xspec
@@ -11,6 +11,9 @@
   <!-- Globally setting url.in.parens to 0 here; tests for url.in.parens handling below modify param value on a oneoff basis -->
   <x:param name="url.in.parens" select="0"/>
 
+  <!-- Globally setting xref.elements.pagenum.in.class to be empty here; specific tests for pagenum class handling below modify param value on a oneoff basis -->
+  <x:param name="xref.elements.pagenum.in.class"/>
+
   <!-- Tests around text nodes for formal XREF elements (those with data-type='xref') -->
   <x:scenario label="When *empty* XREF element is matched">
     <x:context select="(//h:section//h:a[@data-type='xref'])[1]">
@@ -453,6 +456,76 @@
 
       <x:expect label="No URL should be generated in parentheses after the 'a'" test="not(exists(//h:span[@class='print_url_in_parens']))"/>
     </x:scenario>
+  </x:scenario>
+
+  <!-- Tests around "pagenum" classes for XREFs -->
+  <x:scenario label="If XREF is matched">
+    <x:context>
+      <body>
+	<section data-type="chapter" id="first">
+	  <h1>First chapter</h1>
+	  <p>Some text</p>
+	  <p>XREF to second chapter is here: see <a id="chapter_xref" data-type="xref" href="#second"/></p>
+	  <p>Now here's a sidebar:</p>
+	  <aside data-type="sidebar" id="sidebar">
+	    <h5>Sidebar heading</h5>
+	    <p>Sidebar text</p>
+	  </aside>
+	  <p>XREF to the sect1 in second chapter: see <a id="sect1_xref" data-type="xref" href="#chapter2_sect1"/></p>
+	</section>
+	<section data-type="chapter" id="second">
+	  <h1>Second chapter</h1>
+	  <p>Let's add a sect1</p>
+	  <section data-type="sect1" id="chapter2_sect1">
+	    <h1>Subsection heading</h1>
+	    <p>Always soft-code your cross-references</p>
+	    <p>Like this one to the sidebar in the previous chapter: see <a class="underline" id="sidebar_xref" data-type="xref" href="#sidebar"/></p>
+	  </section>
+	</section>
+      </body>
+    </x:context>
+
+    <x:scenario label="that points to an element in the xref.elements.pagenum.in.class list">
+      <x:context select="//h:a[@data-type='xref'][@id='chapter_xref']">
+	<x:param name="xref.elements.pagenum.in.class">chapter
+sidebar
+	</x:param>
+      </x:context>
+      <x:expect label="Class value of 'pagenum' should be added to element" test="exists(//h:a[@class = 'pagenum'])"/>
+    </x:scenario>
+
+    <x:scenario label="that points to an element in the xref.elements.pagenum.in.class list (XREF already has class value)">
+      <x:context select="//h:a[@data-type='xref'][@id='sidebar_xref']">
+	<x:param name="xref.elements.pagenum.in.class">chapter
+sidebar
+	</x:param>
+      </x:context>
+      <x:expect label="Class value of 'pagenum' should be added to element (preserving existing class values)" test="exists(//h:a[@class = 'underline pagenum'])"/>
+    </x:scenario>
+
+    <x:scenario label="that points to an element *not in* the xref.elements.pagenum.in.class list">
+      <x:context select="//h:a[@data-type='xref'][@id='sect1_xref']">
+	<x:param name="xref.elements.pagenum.in.class">chapter
+sidebar
+	</x:param>
+      </x:context>
+      <x:expect label="Class value of 'pagenum' should not be added to element" test="not(exists(//h:a[@class = 'pagenum']))"/>
+    </x:scenario>
+
+    <x:scenario label="with xref.elements.pagenum.in.class empty and no preexisting class on XREF">
+      <x:context select="//h:a[@data-type='xref'][@id='chapter_xref']">
+	<x:param name="xref.elements.pagenum.in.class"/>
+      </x:context>
+      <x:expect label="No class attribute should be added to element" test="not(exists(//h:a[@class]))"/>
+    </x:scenario>
+
+    <x:scenario label="with xref.elements.pagenum.in.class empty and a preexisting class on XREF">
+      <x:context select="//h:a[@data-type='xref'][@id='sidebar_xref']">
+	<x:param name="xref.elements.pagenum.in.class"/>
+      </x:context>
+      <x:expect label="Class attribute should be preserved as is" test="exists(//h:a[@class='underline'])"/>
+    </x:scenario>
+
   </x:scenario>
 
   <x:pending>

--- a/htmlbook-xsl/xspec/common.xspec
+++ b/htmlbook-xsl/xspec/common.xspec
@@ -948,4 +948,97 @@ sect5:none
     <x:expect label="The caption content should contain a label" test="exists(//h:figcaption[h:span[@class='label' and contains(., 'Figure 1')]]) and contains(//h:figcaption[1], 'Touch this caption!')"/>
   </x:scenario>
 
+  <!-- class.attribute handling -->
+  <x:pending>
+    <!-- Not sure XSpec can handle tests that generate just an attribute node, e.g.:
+	  XTDE0420: Cannot create an attribute node (class) whose parent is a document node
+      -->
+    <x:scenario label="If an element is matched in class.attribute modee">
+      <x:context mode="class.attribute"/>
+      
+    <x:scenario label="and its generated class attribute (via class.value) is empty">
+      <x:context>
+	<section data-type="chapter"/>
+      </x:context>
+      <x:expect label="No @class should be generated" test="not(exists(//@class))"/>
+    </x:scenario>
+    
+    <x:scenario label="and its generated class attribute (via class.value) is non empty">
+      <x:context>
+	<section data-type="chapter" class="case-study"/>
+      </x:context>
+      <x:expect label="@class should be generated" test="exists(//@class)"/>
+    </x:scenario>
+    </x:scenario>
+  </x:pending>
+
+  <!-- class.value handling -->
+  <x:scenario label="If XREF is matched in class.value mode">
+    <x:context mode="class.value">
+      <body>
+	<section data-type="chapter" id="first">
+	  <h1>First chapter</h1>
+	  <p>Some text</p>
+	  <p>XREF to second chapter is here: see <a id="chapter_xref" data-type="xref" href="#second"/></p>
+	  <p>Now here's a sidebar:</p>
+	  <aside data-type="sidebar" id="sidebar">
+	    <h5>Sidebar heading</h5>
+	    <p>Sidebar text</p>
+	  </aside>
+	  <p>XREF to the sect1 in second chapter: see <a id="sect1_xref" data-type="xref" href="#chapter2_sect1"/></p>
+	</section>
+	<section data-type="chapter" id="second">
+	  <h1>Second chapter</h1>
+	  <p>Let's add a sect1</p>
+	  <section data-type="sect1" id="chapter2_sect1">
+	    <h1>Subsection heading</h1>
+	    <p>Always soft-code your cross-references</p>
+	    <p>Like this one to the sidebar in the previous chapter: see <a class="underline" id="sidebar_xref" data-type="xref" href="#sidebar"/></p>
+	  </section>
+	</section>
+      </body>
+    </x:context>
+
+    <x:scenario label="that points to an element in the xref.elements.pagenum.in.class list">
+      <x:context select="//h:a[@data-type='xref'][@id='chapter_xref']">
+	<x:param name="xref.elements.pagenum.in.class">chapter
+sidebar
+	</x:param>
+	<x:param name="xref.target" select="//*[@id='second']"/>
+      </x:context>
+      <x:expect label="Class value of 'pagenum' should be returned">pagenum</x:expect>
+    </x:scenario>
+
+    <x:scenario label="that points to an element in the xref.elements.pagenum.in.class list (XREF already has class value)">
+      <x:context select="//h:a[@data-type='xref'][@id='sidebar_xref']">
+	<x:param name="xref.elements.pagenum.in.class">chapter
+sidebar
+	</x:param>
+	<x:param name="xref.target" select="//h:aside[@id='sidebar']"/>
+      </x:context>
+      <x:expect label="Class value of 'pagenum' should be appended to existing class value list">underline pagenum</x:expect>
+    </x:scenario>
+
+    <x:scenario label="that points to an element *not in* the xref.elements.pagenum.in.class list (no existing class)">
+      <x:context select="//h:a[@data-type='xref'][@id='sect1_xref']">
+	<x:param name="xref.elements.pagenum.in.class">chapter
+sidebar
+	</x:param>
+	<x:param name="xref.target" select="//*[@id='chapter2_sect1']"/>
+      </x:context>
+      <x:expect label="Class value of 'pagenum' should not be added. Returned value should be empty" select="()"/>
+    </x:scenario>
+
+    <x:scenario label="that points to an element *not in* the xref.elements.pagenum.in.class list (XREF already has class value)">
+      <x:context select="//h:a[@data-type='xref'][@id='sidebar_xref']">
+	<x:param name="xref.elements.pagenum.in.class">chapter
+sect1
+	</x:param>
+	<x:param name="xref.target" select="//*[@id='sidebar']"/>
+      </x:context>
+      <x:expect label="Class value of 'pagenum' *should not* be added. Class value preserved as is">underline</x:expect>
+    </x:scenario>
+
+  </x:scenario>
+
 </x:description>

--- a/htmlbook-xsl/xspec/xrefgen.xspec
+++ b/htmlbook-xsl/xspec/xrefgen.xspec
@@ -11,6 +11,9 @@
   <!-- Globally setting url.in.parens to 0 here; tests for url.in.parens handling below modify param value on a oneoff basis -->
   <x:param name="url.in.parens" select="0"/>
 
+  <!-- Globally setting xref.elements.pagenum.in.class to be empty here; specific tests for pagenum class handling below modify param value on a oneoff basis -->
+  <x:param name="xref.elements.pagenum.in.class"/>
+
   <!-- Tests around text nodes for formal XREF elements (those with data-type='xref') -->
   <x:scenario label="When *empty* XREF element is matched">
     <x:context select="(//h:section//h:a[@data-type='xref'])[1]">
@@ -851,6 +854,76 @@
 
       <x:expect label="No URL should be generated in parentheses after the 'a'" test="not(exists(//h:span[@class='print_url_in_parens']))"/>
     </x:scenario>
+  </x:scenario>
+
+  <!-- Tests around "pagenum" classes for XREFs -->
+  <x:scenario label="If XREF is matched">
+    <x:context>
+      <body>
+	<section data-type="chapter" id="first">
+	  <h1>First chapter</h1>
+	  <p>Some text</p>
+	  <p>XREF to second chapter is here: see <a id="chapter_xref" data-type="xref" href="#second"/></p>
+	  <p>Now here's a sidebar:</p>
+	  <aside data-type="sidebar" id="sidebar">
+	    <h5>Sidebar heading</h5>
+	    <p>Sidebar text</p>
+	  </aside>
+	  <p>XREF to the sect1 in second chapter: see <a id="sect1_xref" data-type="xref" href="#chapter2_sect1"/></p>
+	</section>
+	<section data-type="chapter" id="second">
+	  <h1>Second chapter</h1>
+	  <p>Let's add a sect1</p>
+	  <section data-type="sect1" id="chapter2_sect1">
+	    <h1>Subsection heading</h1>
+	    <p>Always soft-code your cross-references</p>
+	    <p>Like this one to the sidebar in the previous chapter: see <a class="underline" id="sidebar_xref" data-type="xref" href="#sidebar"/></p>
+	  </section>
+	</section>
+      </body>
+    </x:context>
+
+    <x:scenario label="that points to an element in the xref.elements.pagenum.in.class list">
+      <x:context select="//h:a[@data-type='xref'][@id='chapter_xref']">
+	<x:param name="xref.elements.pagenum.in.class">chapter
+sidebar
+	</x:param>
+      </x:context>
+      <x:expect label="Class value of 'pagenum' should be added to element" test="exists(//h:a[@class = 'pagenum'])"/>
+    </x:scenario>
+
+    <x:scenario label="that points to an element in the xref.elements.pagenum.in.class list (XREF already has class value)">
+      <x:context select="//h:a[@data-type='xref'][@id='sidebar_xref']">
+	<x:param name="xref.elements.pagenum.in.class">chapter
+sidebar
+	</x:param>
+      </x:context>
+      <x:expect label="Class value of 'pagenum' should be added to element (preserving existing class values)" test="exists(//h:a[@class = 'underline pagenum'])"/>
+    </x:scenario>
+
+    <x:scenario label="that points to an element *not in* the xref.elements.pagenum.in.class list">
+      <x:context select="//h:a[@data-type='xref'][@id='sect1_xref']">
+	<x:param name="xref.elements.pagenum.in.class">chapter
+sidebar
+	</x:param>
+      </x:context>
+      <x:expect label="Class value of 'pagenum' should not be added to element" test="not(exists(//h:a[@class = 'pagenum']))"/>
+    </x:scenario>
+
+    <x:scenario label="with xref.elements.pagenum.in.class empty and no preexisting class on XREF">
+      <x:context select="//h:a[@data-type='xref'][@id='chapter_xref']">
+	<x:param name="xref.elements.pagenum.in.class"/>
+      </x:context>
+      <x:expect label="No class attribute should be added to element" test="not(exists(//h:a[@class]))"/>
+    </x:scenario>
+
+    <x:scenario label="with xref.elements.pagenum.in.class empty and a preexisting class on XREF">
+      <x:context select="//h:a[@data-type='xref'][@id='sidebar_xref']">
+	<x:param name="xref.elements.pagenum.in.class"/>
+      </x:context>
+      <x:expect label="Class attribute should be preserved as is" test="exists(//h:a[@class='underline'])"/>
+    </x:scenario>
+
   </x:scenario>
 
   <!-- Tests for whether an HREF is considered to be an XREF (link within the same corpus) -->


### PR DESCRIPTION
This pull request adds handling to generate "pagenum" class values on designated XREFs for paged outputs (print/Web PDF) in order to facilitate CSS Paged Media styling to add page number gentext (via the `target-counter()` function: http://dev.w3.org/csswg/css-gcpm/#target-counter).

The HTMLBook XSL now has available a parameter called `xref.elements.pagenum.in.class`, which takes a newline-separated list of elements (element names are "semantic" names defined in the `semantic-name` template in common.xsl), e.g.:

``` xml
<xsl:param name="xref.elements.pagenum.in.class">
sect1
sect2
sect3
sect4
sect5
sidebar
</xsl:param>
```

 Any XREFs pointing to an element in this list will have `pagenum` added to their `class` attribute value.
