### PR TITLE
Fixed guide-generation bug

### DIFF
--- a/htmlbook-xsl/opf.xsl
+++ b/htmlbook-xsl/opf.xsl
@@ -449,7 +449,7 @@
 	  <!-- Otherwise, just use the first <section> in the text -->
 	  <xsl:otherwise>
 	    <xsl:call-template name="output-filename-for-chunk">
-	      <xsl:with-param name="node" select="//h:section[1]"/>
+	      <xsl:with-param name="node" select="(//h:section)[1]"/>
 	    </xsl:call-template>
 	  </xsl:otherwise>
 	</xsl:choose>

--- a/htmlbook-xsl/xspec/opf.xspec
+++ b/htmlbook-xsl/xspec/opf.xspec
@@ -511,15 +511,29 @@ UbuntuMono-Regular.otf
 	</x:param>
       </x:call>
       <!-- Note, we can't access document context from a named template, so we can't check hrefs here, but at least we can check for existence of elements -->
+      <!-- ToDo: parameterize context node for generate-guide so hrefs can be tested, and pending tests can be filled in -->
       <x:expect label="There should be a reference element for the cover if generate.cover.html is enabled" test="exists(/opf:guide/opf:reference[@type='cover'])"/>
       <x:expect label="There should be a reference element to the EPUB Nav doc" test="exists(/opf:guide/opf:reference[@type='toc'])"/>
-      <x:expect label="There should be a reference element for 'start-of-text'" test="exists(/opf:guide/opf:reference[@type='text'])"/>
       <x:scenario label="With generate.cover.html disabled">
 	<x:call>
 	  <x:param name="generate.cover.html"/>
 	</x:call>
 	<x:expect label="There *should not* be a reference element for the cover" test="not(exists(/opf:guide/opf:reference[@type='cover']))"/>
       </x:scenario>
+
+      <x:pending>
+	<x:scenario label="On content that contains a titlepage">
+	  
+	</x:scenario>
+	
+	<x:scenario label="On content that contains no titlepage, but does contain a TOC">
+	  
+	</x:scenario>
+	
+	<x:scenario label="On content that contains no titlepage or cover">
+	  
+	</x:scenario>
+      </x:pending>
     </x:scenario>
 
     <x:scenario label="When element is matched in opf.spine.itemref mode">


### PR DESCRIPTION
Fixed bug in start-of-text guide element generation when book does not have titlepage or cover.
