### PR TITLE
Whitespace-stripping handling for indexterms

### DIFF
--- a/htmlbook-xsl/common.xsl
+++ b/htmlbook-xsl/common.xsl
@@ -680,4 +680,25 @@
     </xsl:choose>
   </xsl:template>
 
+  <!-- Returns 1 when a text node contains only whitespace (defined as standard space chars or nbsp chars) -->
+  <!-- Otherwise returns 0 -->
+  <xsl:template name="whitespace-only-in-text">
+    <xsl:param name="text.content" select="."/>
+    <xsl:choose>
+      <!-- Fine to consider empty text nodes to be whitespace-only; facilitates recursion here -->
+      <xsl:when test="string-length($text.content) = 0">1</xsl:when>
+      <xsl:when test="(substring($text.content, 1, 1) = ' ') or 
+		      (substring($text.content, 1, 1) = '&#xa0;')">
+	<!-- If first character is a whitespace char, recurse on rest of string to see if it's all whitespace -->
+	<xsl:call-template name="whitespace-only-in-text">
+	  <xsl:with-param name="text.content">
+	    <xsl:value-of select="substring($text.content, 2)"/>
+	  </xsl:with-param>
+	</xsl:call-template>
+      </xsl:when>
+      <!-- Otherwise, there's at least 1 text character, so return 0 (false) -->
+      <xsl:otherwise>0</xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
 </xsl:stylesheet> 

--- a/htmlbook-xsl/elements.xsl
+++ b/htmlbook-xsl/elements.xsl
@@ -66,6 +66,20 @@
     </xsl:copy>
   </xsl:template>
 
+  <!-- Special handling for indexterm text nodes when there are no sibling text or element nodes -->
+  <xsl:template match="h:a[@data-type='indexterm']/text()[not(preceding-sibling::node()) and not(following-sibling::node())]">
+    <xsl:variable name="whitespace-only-in-indexterm">
+      <xsl:call-template name="whitespace-only-in-text">
+	<xsl:with-param name="text.content" select="."/>
+      </xsl:call-template>
+    </xsl:variable>
+    <!-- Only copy over text when it's not whitespace-only -->
+    <!-- In other words, strip out whitespace-only text nodes in indexterms -->
+    <xsl:if test="$whitespace-only-in-indexterm != 1">
+     <xsl:value-of select="."/>
+    </xsl:if>
+  </xsl:template>
+
   <xsl:template match="h:section[@data-type]/*[self::h:h1 or self::h:h2 or self::h:h3 or self::h:h4 or self::h:h5 or self::h:h6]|
 		       h:section[@data-type]/h:header/*[self::h:h1 or self::h:h2 or self::h:h3 or self::h:h4 or self::h:h5 or self::h:h6]|
 		       h:div[@data-type = 'part' or @data-type = 'example' or @data-type = 'equation']/*[self::h:h1 or self::h:h2 or self::h:h3 or self::h:h4 or self::h:h5 or self::h:h6]|

--- a/htmlbook-xsl/xspec/common.xspec
+++ b/htmlbook-xsl/xspec/common.xspec
@@ -1041,4 +1041,74 @@ sect1
 
   </x:scenario>
 
+  <x:scenario label="When calling whitespace-only-in-text on an empty text node">
+    <x:call template="whitespace-only-in-text">
+      <x:param name="text.content" select="''"/>
+    </x:call>
+    <x:expect label="It should return 'true'">1</x:expect>
+  </x:scenario>
+
+  <x:scenario label="When calling whitespace-only-in-text on a single space character">
+    <x:call template="whitespace-only-in-text">
+      <x:param name="text.content" select="' '"/>
+    </x:call>
+    <x:expect label="It should return 'true'">1</x:expect>
+  </x:scenario>
+
+  <x:scenario label="When calling whitespace-only-in-text on an nbsp character">
+    <x:call template="whitespace-only-in-text">
+      <x:param name="text.content" select="'&#xa0;'"/>
+    </x:call>
+    <x:expect label="It should return 'true'">1</x:expect>
+  </x:scenario>
+
+  <x:scenario label="When calling whitespace-only-in-text on a word character">
+    <x:call template="whitespace-only-in-text">
+      <x:param name="text.content" select="'b'"/>
+    </x:call>
+    <x:expect label="It should return 'false'">0</x:expect>
+  </x:scenario>
+
+  <x:scenario label="When calling whitespace-only-in-text on a mix of whitespace character">
+    <x:call template="whitespace-only-in-text">
+      <x:param name="text.content" select="' &#xa0;  '"/>
+    </x:call>
+    <x:expect label="It should return 'true'">1</x:expect>
+  </x:scenario>
+
+  <x:scenario label="When calling whitespace-only-in-text on a mix of whitespace character (2)">
+    <x:call template="whitespace-only-in-text">
+      <x:param name="text.content" select="'    '"/>
+    </x:call>
+    <x:expect label="It should return 'true'">1</x:expect>
+  </x:scenario>
+
+  <x:scenario label="When calling whitespace-only-in-text on a mix of whitespace character (3)">
+    <x:call template="whitespace-only-in-text">
+      <x:param name="text.content" select="'&#xa0;&#xa0;&#xa0;'"/>
+    </x:call>
+    <x:expect label="It should return 'true'">1</x:expect>
+  </x:scenario>
+
+  <x:scenario label="When calling whitespace-only-in-text on a mix of word characters">
+    <x:call template="whitespace-only-in-text">
+      <x:param name="text.content" select="'chocolatechipcookies'"/>
+    </x:call>
+    <x:expect label="It should return 'false'">0</x:expect>
+  </x:scenario>
+
+  <x:scenario label="When calling whitespace-only-in-text on a mix of word and whitespace characters">
+    <x:call template="whitespace-only-in-text">
+      <x:param name="text.content" select="'chocolate chip cookies'"/>
+    </x:call>
+    <x:expect label="It should return 'false'">0</x:expect>
+  </x:scenario>
+
+  <x:scenario label="When calling whitespace-only-in-text on a mix of word and whitespace characters (2)">
+    <x:call template="whitespace-only-in-text">
+      <x:param name="text.content" select="'chocolate&#xa0;chip cookies'"/>
+    </x:call>
+    <x:expect label="It should return 'false'">0</x:expect>
+  </x:scenario>
+
 </x:description>

--- a/htmlbook-xsl/xspec/elements.xspec
+++ b/htmlbook-xsl/xspec/elements.xspec
@@ -72,6 +72,7 @@ sect5:1
     <x:expect label="Preserve the id" test="h:aside[1]/@id = 'watermelon'"/>
   </x:scenario>
 
+  <!-- Indexterm tests -->
   <x:scenario label="When encountering an indexterm without an id">
     <x:context>
       <a data-type="indexterm" data-primary="rubygems"/>
@@ -86,6 +87,69 @@ sect5:1
     </x:context>
     <!-- check the result -->
     <x:expect label="Preserve the id" test="h:a[@data-type='indexterm'][1]/@id = 'avocado'"/>
+  </x:scenario>
+
+  <x:scenario label="When encountering an indexterm that contains only whitespace">
+    <x:context>
+      <a data-type="indexterm" data-primary="xslt" data-secondary="xml and">   </a>
+    </x:context>
+    <x:expect label="Strip the whitespace">
+      <a data-type="indexterm" data-primary="xslt" data-secondary="xml and" id="..."/>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="When encountering an indexterm that contains only whitespace (including nbsp)">
+    <x:context>
+      <a data-type="indexterm" data-primary="xslt" data-secondary="xml and">&#xa0; &#xa0;</a>
+    </x:context>
+    <x:expect label="Strip the whitespace">
+      <a data-type="indexterm" data-primary="xslt" data-secondary="xml and" id="..."/>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="When encountering an indexterm that contains text and whitespace">
+    <x:context>
+      <a data-type="indexterm" data-primary="xslt" data-secondary="xml and">Unicode&#xa0; &#xa0;is fun</a>
+    </x:context>
+    <x:expect label="Preserve content as is">
+      <a data-type="indexterm" data-primary="xslt" data-secondary="xml and" id="...">Unicode&#xa0; &#xa0;is fun</a>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="When encountering an indexterm that contains child nodes only">
+    <x:context>
+      <a data-type="indexterm" data-primary="xslt" data-secondary="xml and"><em>Unicode</em></a>
+    </x:context>
+    <x:expect label="Preserve content as is">
+      <a data-type="indexterm" data-primary="xslt" data-secondary="xml and" id="..."><em>Unicode</em></a>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="When encountering an indexterm that contains child nodes only (2)">
+    <x:context>
+      <a data-type="indexterm" data-primary="xslt" data-secondary="xml and"><br/></a>
+    </x:context>
+    <x:expect label="Preserve content as is">
+      <a data-type="indexterm" data-primary="xslt" data-secondary="xml and" id="..."><br/></a>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="When encountering an indexterm that contains child nodes and text">
+    <x:context>
+      <a data-type="indexterm" data-primary="xslt" data-secondary="xml and"><em>123</em>456</a>
+    </x:context>
+    <x:expect label="Preserve content as is">
+      <a data-type="indexterm" data-primary="xslt" data-secondary="xml and" id="..."><em>123</em>456</a>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="When encountering an indexterm that contains child nodes, text, and whitespace">
+    <x:context>
+      <a data-type="indexterm" data-primary="xslt" data-secondary="xml and"><em>Unicode</em>&#xa0; &#xa0;is fun</a>
+    </x:context>
+    <x:expect label="Preserve content as is">
+      <a data-type="indexterm" data-primary="xslt" data-secondary="xml and" id="..."><em>Unicode</em>&#xa0; &#xa0;is fun</a>
+    </x:expect>
   </x:scenario>
 
   <!-- PDF bookmark attributes -->


### PR DESCRIPTION
If the text node of an indexterm has no preceding or following siblings (e.g., other element nodes), and its text is only standard space characters (U+0020) or nonbreaking spaces (U+00A0), then strip out this whitespace during XSL stylesheet processing.
