### PR TITLE
Clarification on blockquote specs around use of "epigraph" semantic inflection

### DIFF
--- a/index.html
+++ b/index.html
@@ -535,7 +535,7 @@ now free to be used for whatever user-defined semantics are desired, and there a
   &lt;p&gt;When in the course of human events...&lt;/p&gt;
   &lt;p data-type="attribution"&gt;U.S. Declaration of Independence&lt;/p&gt;
 &lt;/blockquote&gt;</pre>
-	<p><strong>Note</strong>: If the blockquote is an epigraph, add <code>data-type="attribute"</code>, e.g.:</p>
+	<p><strong>Note</strong>: If the blockquote is an epigraph, add <code>data-type="epigraph"</code>, e.g.:</p>
 	<pre data-type="programlisting">&lt;section data-type="chapter"&gt;
   &lt;h1&gt;Conclusion&lt;/h1&gt;
   &lt;blockquote data-type="epigraph"&gt;


### PR DESCRIPTION
Clarification on blockquote specs around use of `data-type="epigraph"`
