### PR TITLE
More robust URL-compare function

### DIFF
--- a/htmlbook-xsl/xrefgen.xsl
+++ b/htmlbook-xsl/xrefgen.xsl
@@ -619,17 +619,38 @@
   <!-- Template to trim http:// and http://www from URLs -->
   <xsl:template name="trim-url">
     <xsl:param name="url-to-trim"/>
-    <xsl:choose>
-      <xsl:when test="contains($url-to-trim, 'http://www.')">
-	<xsl:value-of select="substring-after($url-to-trim, 'http://www.')"/>
-      </xsl:when>
-      <xsl:when test="contains($url-to-trim, 'http://')">
-	<xsl:value-of select="substring-after($url-to-trim, 'http://')"/>
-      </xsl:when>
-      <xsl:otherwise>
-	<xsl:value-of select="$url-to-trim"/>
-      </xsl:otherwise>
-    </xsl:choose>
+
+    <!-- First, trim http://www., http://, or www. prefixes -->
+    <xsl:variable name="prefix-trimmed">
+      <xsl:choose>
+	<xsl:when test="contains($url-to-trim, 'http://www.') and substring-before($url-to-trim, 'http://www.') = ''">
+	  <xsl:value-of select="substring-after($url-to-trim, 'http://www.')"/>
+	</xsl:when>
+	<xsl:when test="contains($url-to-trim, 'http://') and substring-before($url-to-trim, 'http://') = ''">
+	  <xsl:value-of select="substring-after($url-to-trim, 'http://')"/>
+	</xsl:when>
+	<xsl:when test="contains($url-to-trim, 'www.') and substring-before($url-to-trim, 'www.') = ''">
+	  <xsl:value-of select="substring-after($url-to-trim, 'www.')"/>
+	</xsl:when>
+	<xsl:otherwise>
+	  <xsl:value-of select="$url-to-trim"/>
+	</xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+
+    <!-- Then trim trailing forward slashes -->
+    <xsl:variable name="suffix-trimmed">
+      <xsl:choose>
+	<xsl:when test="substring($prefix-trimmed, string-length($prefix-trimmed), 1) = '/'">
+	  <xsl:value-of select="substring($prefix-trimmed, 1, string-length($prefix-trimmed) - 1)"/>
+	</xsl:when>
+	<xsl:otherwise>
+	  <xsl:value-of select="$prefix-trimmed"/>
+	</xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+    
+    <xsl:value-of select="$suffix-trimmed"/>
   </xsl:template>
 
 </xsl:stylesheet> 

--- a/htmlbook-xsl/xspec/xrefgen.xspec
+++ b/htmlbook-xsl/xspec/xrefgen.xspec
@@ -708,6 +708,11 @@
         <p><a id="hyperlink_same_text_node" href="http://oreilly.com">http://oreilly.com</a></p>
         <p><a id="hyperlink_same_text_node_2" href="http://oreilly.com">oreilly.com</a></p>
         <p><a id="hyperlink_same_text_node_3" href="http://www.oreilly.com">oreilly.com</a></p>
+	<p><a id="hyperlink_same_text_node_4" href="http://www.oreilly.com">www.oreilly.com</a></p>
+        <p><a id="hyperlink_same_text_node_5" href="http://oreilly.com/">http://oreilly.com</a></p>
+        <p><a id="hyperlink_same_text_node_6" href="http://oreilly.com/">oreilly.com</a></p>
+        <p><a id="hyperlink_same_text_node_7" href="http://www.oreilly.com/">oreilly.com</a></p>
+	<p><a id="hyperlink_same_text_node_8" href="http://www.oreilly.com/">www.oreilly.com</a></p>
         <p><a id="link" data-type="link" href="#some_id">some awesome location in the text</a></p>
 	<p><a href="#another_id" id="stealth_xref">XREF masquerading as an external hyperlink (no proper data-type)</a></p>
         <p><a id="email_me" href="mailto:tools@oreilly.com">tools@oreilly.com</a></p>
@@ -745,6 +750,46 @@
       
       <x:expect label="No URL should be generated in parentheses after the 'a'" test="not(exists(//h:span[@class='print_url_in_parens']))"/>
     </x:scenario> 
+
+    <x:scenario label="with url.in.parens disabled (hyperlink same text node as href 4)">
+      <x:context select="//h:a[@id='hyperlink_same_text_node_4']">
+        <x:param name="url.in.parens" select="0"/>
+      </x:context>
+      
+      <x:expect label="No URL should be generated in parentheses after the 'a'" test="not(exists(//h:span[@class='print_url_in_parens']))"/>
+    </x:scenario>
+
+    <x:scenario label="with url.in.parens disabled (hyperlink same text node as href 5)">
+      <x:context select="//h:a[@id='hyperlink_same_text_node_5']">
+        <x:param name="url.in.parens" select="0"/>
+      </x:context>
+      
+      <x:expect label="No URL should be generated in parentheses after the 'a'" test="not(exists(//h:span[@class='print_url_in_parens']))"/>
+    </x:scenario>
+
+    <x:scenario label="with url.in.parens disabled (hyperlink same text node as href 6)">
+      <x:context select="//h:a[@id='hyperlink_same_text_node_6']">
+        <x:param name="url.in.parens" select="0"/>
+      </x:context>
+      
+      <x:expect label="No URL should be generated in parentheses after the 'a'" test="not(exists(//h:span[@class='print_url_in_parens']))"/>
+    </x:scenario>
+
+    <x:scenario label="with url.in.parens disabled (hyperlink same text node as href 7)">
+      <x:context select="//h:a[@id='hyperlink_same_text_node_7']">
+        <x:param name="url.in.parens" select="0"/>
+      </x:context>
+      
+      <x:expect label="No URL should be generated in parentheses after the 'a'" test="not(exists(//h:span[@class='print_url_in_parens']))"/>
+    </x:scenario>
+
+    <x:scenario label="with url.in.parens disabled (hyperlink same text node as href 8)">
+      <x:context select="//h:a[@id='hyperlink_same_text_node_8']">
+        <x:param name="url.in.parens" select="0"/>
+      </x:context>
+      
+      <x:expect label="No URL should be generated in parentheses after the 'a'" test="not(exists(//h:span[@class='print_url_in_parens']))"/>
+    </x:scenario>
     
     <x:scenario label="with url.in.parens disabled (internal link)">
       <x:context select="//h:a[@id='link']">
@@ -798,6 +843,46 @@
     
     <x:scenario label="with url.in.parens enabled (hyperlink same text node as href 3)">
       <x:context select="//h:a[@id='hyperlink_same_text_node_3']">
+        <x:param name="url.in.parens" select="1"/>
+      </x:context>
+      
+      <x:expect label="No URL should be generated in parentheses after the 'a'" test="not(exists(//h:span[@class='print_url_in_parens']))"/>
+    </x:scenario>
+
+    <x:scenario label="with url.in.parens enabled (hyperlink same text node as href 4)">
+      <x:context select="//h:a[@id='hyperlink_same_text_node_4']">
+        <x:param name="url.in.parens" select="1"/>
+      </x:context>
+      
+      <x:expect label="No URL should be generated in parentheses after the 'a'" test="not(exists(//h:span[@class='print_url_in_parens']))"/>
+    </x:scenario> 
+
+    <x:scenario label="with url.in.parens enabled (hyperlink same text node as href 5)">
+      <x:context select="//h:a[@id='hyperlink_same_text_node_5']">
+        <x:param name="url.in.parens" select="1"/>
+      </x:context>
+      
+      <x:expect label="No URL should be generated in parentheses after the 'a'" test="not(exists(//h:span[@class='print_url_in_parens']))"/>
+    </x:scenario> 
+
+    <x:scenario label="with url.in.parens enabled (hyperlink same text node as href 6)">
+      <x:context select="//h:a[@id='hyperlink_same_text_node_6']">
+        <x:param name="url.in.parens" select="1"/>
+      </x:context>
+      
+      <x:expect label="No URL should be generated in parentheses after the 'a'" test="not(exists(//h:span[@class='print_url_in_parens']))"/>
+    </x:scenario> 
+
+    <x:scenario label="with url.in.parens enabled (hyperlink same text node as href 7)">
+      <x:context select="//h:a[@id='hyperlink_same_text_node_7']">
+        <x:param name="url.in.parens" select="1"/>
+      </x:context>
+      
+      <x:expect label="No URL should be generated in parentheses after the 'a'" test="not(exists(//h:span[@class='print_url_in_parens']))"/>
+    </x:scenario> 
+
+    <x:scenario label="with url.in.parens enabled (hyperlink same text node as href 8)">
+      <x:context select="//h:a[@id='hyperlink_same_text_node_8']">
         <x:param name="url.in.parens" select="1"/>
       </x:context>
       
@@ -1033,18 +1118,54 @@ sidebar
     </x:call>
     <x:expect label="Trimmed URL should be returned without http://">oreilly.com</x:expect>
   </x:scenario>
-  
-  <x:scenario label="If trim-url is called on URL text starting with http://www">
+
+  <x:scenario label="If trim-url is called on URL text starting with www.">
     <x:call template="trim-url">
-      <x:param name="url-to-trim">http://www.oreilly.com</x:param>
+      <x:param name="url-to-trim">www.oreilly.com</x:param>
     </x:call>
     <x:expect label="Trimmed URL should be returned without http://">oreilly.com</x:expect>
   </x:scenario>
   
-  <x:scenario label="If trim-url is called on URL text that does not start with http://">
+  <x:scenario label="If trim-url is called on URL text starting with http://www.">
+    <x:call template="trim-url">
+      <x:param name="url-to-trim">http://www.oreilly.com</x:param>
+    </x:call>
+    <x:expect label="Trimmed URL should be returned without http://www.">oreilly.com</x:expect>
+  </x:scenario>
+
+  <x:scenario label="If trim-url is called on URL text that ends in a forward slash">
+    <x:call template="trim-url">
+      <x:param name="url-to-trim">oreilly.com/</x:param>
+    </x:call>
+    <x:expect label="Trimmed URL should be returned without ending forward slash">oreilly.com</x:expect>
+  </x:scenario>
+
+  <x:scenario label="If trim-url is called on URL text starting with http:// and ending with a forward slash">
+    <x:call template="trim-url">
+      <x:param name="url-to-trim">http://oreilly.com/</x:param>
+    </x:call>
+    <x:expect label="Trimmed URL should be returned without http:// and trailing forward slash">oreilly.com</x:expect>
+  </x:scenario>
+
+  <x:scenario label="If trim-url is called on URL text starting with www. and ending with a forward slash">
+    <x:call template="trim-url">
+      <x:param name="url-to-trim">www.oreilly.com/</x:param>
+    </x:call>
+    <x:expect label="Trimmed URL should be returned without http:// and trailing forward slash">oreilly.com</x:expect>
+  </x:scenario>
+  
+  <x:scenario label="If trim-url is called on URL text starting with http://www. and ending with a forward slash">
+    <x:call template="trim-url">
+      <x:param name="url-to-trim">http://www.oreilly.com/</x:param>
+    </x:call>
+    <x:expect label="Trimmed URL should be returned without http://www. and trailing forward slash">oreilly.com</x:expect>
+  </x:scenario>
+  
+  <x:scenario label="If trim-url is called on URL text that does not start with http:// or www, or end with a forward slash.">
     <x:call template="trim-url">
       <x:param name="url-to-trim">oreilly.com</x:param>
     </x:call>
     <x:expect label="Trimmed URL should be returned as is">oreilly.com</x:expect>
   </x:scenario>
+
 </x:description>


### PR DESCRIPTION
The trim-url function for comparing URLs to determine if they are "identical" (for purposes of displaying the URL following the text node for print outputs) is now more robust and ignores the following when determining "identicalness":
- Trailing forward slashes (e.g., "http://www.oreilly.com/")
- Opening www. not preceded by http:// (e.g., "www.oreilly.com")
