### PR TITLE
fix schema rules for <tr> to allow mixing <th> and <td> children within ...

### DIFF
--- a/schema/htmlbook.xsd
+++ b/schema/htmlbook.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.w3.org/1999/xhtml" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:svg="http://www.w3.org/2000/svg" targetNamespace="http://www.w3.org/1999/xhtml" elementFormDefault="qualified" attributeFormDefault="unqualified">
 
 <xs:import namespace="http://www.w3.org/1998/Math/MathML" schemaLocation="mathml3/mathml3.xsd"/>
@@ -1458,10 +1458,7 @@
   
 <xs:element name="tr">
   <xs:complexType>
-    <xs:choice>
-      <xs:element ref="td" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element ref="th" minOccurs="0" maxOccurs="unbounded"/>
-    </xs:choice>
+    <xs:group ref="table_cells" minOccurs="0" maxOccurs="unbounded"/>
     <xs:attributeGroup ref="globals"/>
   </xs:complexType>
 </xs:element>
@@ -2015,6 +2012,13 @@
   <xs:choice>
     <xs:group ref="inlineelements"/>
     <xs:group ref="external_elements"/>
+  </xs:choice>
+</xs:group>
+
+<xs:group name="table_cells">
+  <xs:choice>
+    <xs:element ref="th"/>
+    <xs:element ref="td"/>
   </xs:choice>
 </xs:group>
   


### PR DESCRIPTION
...the same &lt;tr&gt; element as it is in the HTML5 specification

Before, marking up a  &lt;tr&gt; where the first child is a  &lt;th&gt; with  &lt;td&gt; siblings, the htmlbook file will fail validation because the xsd rules expects more of the same kind, not allowing to mix &lt;th&gt; and <td> in the same  &lt;tr&gt;.

This change reflects the html5 spec that allows mixing any number of  &lt;th&gt; and  &lt;td&gt; children inside a  &lt;tr&gt; element.

I think the concept of HTMLBook is very interesting. I will be watching as it evolves, and contribute with little things that I can. We (a project group at Oslo and Akershus University College) are evaluating different starting points in an epub3 generation pipeline. Initially we were going to compare NLM book and DocBook5, but after discovering the work done with HTMLBook, it has to be seriously considered as well.
