### PR TITLE
New parameter for resetting footnote numbering at chapter level

### DIFF
--- a/htmlbook-xsl/elements.xsl
+++ b/htmlbook-xsl/elements.xsl
@@ -24,6 +24,7 @@
   <!-- WARNING: If you need additional handling for these elements for other functionality,
        and you override this template elsewhere, make sure you add in id-decoration functionality -->
   <xsl:template match="h:section|h:div[contains(@data-type, 'part')]|h:aside|h:a[contains(@data-type, 'indexterm')]">
+    <xsl:param name="process.footnotes" select="$process.footnotes"/>
     <xsl:param name="html4.structural.elements" select="$html4.structural.elements"/>
     <xsl:variable name="output-element-name">
       <xsl:call-template name="html.output.element">
@@ -217,6 +218,7 @@
 
   <!-- Footnote handling -->
   <xsl:template match="h:span[@data-type='footnote']">
+    <xsl:param name="process.footnotes" select="$process.footnotes"/>
     <xsl:choose>
       <xsl:when test="$process.footnotes = 1">
 	<xsl:call-template name="footnote-marker"/>
@@ -248,6 +250,7 @@
 
   <!-- Handling for footnoterefs a la DocBook (cross-references to an existing footnote) -->
   <xsl:template match="h:a[@data-type='footnoteref']">
+    <xsl:param name="process.footnotes" select="$process.footnotes"/>
     <xsl:choose>
       <xsl:when test="$process.footnotes = 1">
 	<xsl:variable name="referenced-footnote-id">

--- a/htmlbook-xsl/elements.xsl
+++ b/htmlbook-xsl/elements.xsl
@@ -397,6 +397,7 @@
   </xsl:template>
 
   <xsl:template match="h:span[@data-type='footnote']" mode="generate.footnote">
+    <xsl:param name="footnote.reset.numbering.at.chapter.level" select="$footnote.reset.numbering.at.chapter.level"/>
     <p data-type="footnote">
       <xsl:attribute name="id">
 	<xsl:call-template name="object.id"/>
@@ -409,7 +410,9 @@
 	<sup>
 	  <!-- Use numbers for footnotes -->
 	  <!-- ToDo: Parameterize for numeration type and/or symbols? -->
-	  <xsl:apply-templates select="." mode="footnote.number"/>
+	  <xsl:apply-templates select="." mode="footnote.number">
+	    <xsl:with-param name="footnote.reset.numbering.at.chapter.level" select="$footnote.reset.numbering.at.chapter.level"/>
+	  </xsl:apply-templates>
 	</sup>
       </a>
       <xsl:text> </xsl:text>

--- a/htmlbook-xsl/elements.xsl
+++ b/htmlbook-xsl/elements.xsl
@@ -270,10 +270,13 @@
 
   <!-- Footnote handling -->
   <xsl:template match="h:span[@data-type='footnote']">
+    <xsl:param name="footnote.reset.numbering.at.chapter.level" select="$footnote.reset.numbering.at.chapter.level"/>
     <xsl:param name="process.footnotes" select="$process.footnotes"/>
     <xsl:choose>
       <xsl:when test="$process.footnotes = 1">
-	<xsl:call-template name="footnote-marker"/>
+	<xsl:apply-templates select="." mode="footnote.marker">
+	  <xsl:with-param name="footnote.reset.numbering.at.chapter.level" select="$footnote.reset.numbering.at.chapter.level"/>
+	</xsl:apply-templates>
       </xsl:when>
       <xsl:otherwise>
 	<xsl:copy>
@@ -283,7 +286,8 @@
     </xsl:choose>
   </xsl:template>
 
-  <xsl:template name="footnote-marker">
+  <xsl:template match="h:span[@data-type='footnote']" mode="footnote.marker" name="footnote-marker">
+    <xsl:param name="footnote.reset.numbering.at.chapter.level" select="$footnote.reset.numbering.at.chapter.level"/>
     <a data-type="noteref">
       <xsl:attribute name="id">
 	<xsl:call-template name="object.id"/>
@@ -295,13 +299,16 @@
       <sup>
 	<!-- Use numbers for footnotes -->
 	<!-- ToDo: Parameterize for numeration type and/or symbols? -->
-	<xsl:number count="h:span[@data-type='footnote']" level="any"/>
+	<xsl:apply-templates select="." mode="footnote.number">
+	  <xsl:with-param name="footnote.reset.numbering.at.chapter.level" select="$footnote.reset.numbering.at.chapter.level"/>
+	</xsl:apply-templates>
       </sup>
     </a>
   </xsl:template>
 
   <!-- Handling for footnoterefs a la DocBook (cross-references to an existing footnote) -->
   <xsl:template match="h:a[@data-type='footnoteref']">
+    <xsl:param name="footnote.reset.numbering.at.chapter.level" select="$footnote.reset.numbering.at.chapter.level"/>
     <xsl:param name="process.footnotes" select="$process.footnotes"/>
     <xsl:choose>
       <xsl:when test="$process.footnotes = 1">
@@ -322,7 +329,9 @@
 		<sup>
 		  <!-- Use numbers for footnotes -->
 		  <!-- ToDo: Parameterize for numeration type and/or symbols? -->
-		  <xsl:number count="h:span[@data-type='footnote']" level="any"/>
+		  <xsl:apply-templates select="." mode="footnote.number">
+		    <xsl:with-param name="footnote.reset.numbering.at.chapter.level" select="$footnote.reset.numbering.at.chapter.level"/>
+		  </xsl:apply-templates>
 		</sup>
 	  </a>
 	    </xsl:for-each>
@@ -344,6 +353,23 @@
 	<xsl:copy>
 	  <xsl:apply-templates select="@*|node()"/>
 	</xsl:copy>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <!-- Template for numbering footnotes -->
+  <xsl:template match="h:span[@data-type='footnote']" mode="footnote.number">
+    <xsl:param name="footnote.reset.numbering.at.chapter.level" select="$footnote.reset.numbering.at.chapter.level"/>
+    <xsl:choose>
+      <xsl:when test="$footnote.reset.numbering.at.chapter.level = 1">
+	<!-- Count footnote only from most recent chapter-level element -->
+	<xsl:number count="h:span[@data-type='footnote']" level="any" from="h:section[parent::h:body or 
+									              parent::h:div[@data-type='part'] or
+										      not(ancestor::h:section)]"/>
+      </xsl:when>
+      <xsl:otherwise>
+	<!-- Count footnotes from beginning of content -->
+	<xsl:number count="h:span[@data-type='footnote']" level="any"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
@@ -383,7 +409,7 @@
 	<sup>
 	  <!-- Use numbers for footnotes -->
 	  <!-- ToDo: Parameterize for numeration type and/or symbols? -->
-	  <xsl:number count="h:span[@data-type='footnote']" level="any"/>
+	  <xsl:apply-templates select="." mode="footnote.number"/>
 	</sup>
       </a>
       <xsl:text> </xsl:text>

--- a/htmlbook-xsl/epub.xsl
+++ b/htmlbook-xsl/epub.xsl
@@ -273,12 +273,13 @@ UbuntuMono-Italic.otf</xsl:param>
     </xsl:result-document>
   </xsl:template>
 
-  <xsl:template match="@data-type">
-    <xsl:copy-of select="."/>
+  <xsl:template match="@data-type" name="data-type">
+    <xsl:param name="data-type-node" select="."/>
+    <xsl:copy-of select="$data-type-node"/>
     <xsl:choose>
-      <xsl:when test=". = $valid.epub.type.values//e:epubtype">
+      <xsl:when test="$data-type-node = $valid.epub.type.values//e:epubtype">
 	<xsl:attribute name="epub:type">
-	  <xsl:value-of select="."/>
+	  <xsl:value-of select="$data-type-node"/>
 	</xsl:attribute>
       </xsl:when>
       <xsl:otherwise>

--- a/htmlbook-xsl/param.xsl
+++ b/htmlbook-xsl/param.xsl
@@ -174,6 +174,9 @@ toc:lower-roman
   <!-- Process footnotes into separate marker/hyperlink and footnote content -->
   <xsl:param name="process.footnotes" select="0"/>
 
+  <!-- Reset footnote numbering at chapter level elements (children of part or body) -->
+  <xsl:param name="footnote.reset.numbering.at.chapter.level" select="1"/>
+
   <!-- Admonition-specific params -->
   <!-- Add title heading elements for different admonition types that do not already have headings in markup -->
   <xsl:param name="add.title.heading.for.admonitions" select="0"/>

--- a/htmlbook-xsl/xspec/elements.xspec
+++ b/htmlbook-xsl/xspec/elements.xspec
@@ -1434,4 +1434,60 @@ sect5:1
     </x:scenario>
   </x:scenario>
 
+  <!-- Footnote tests -->
+  <x:scenario label="When a footnote is matched">
+    <x:context select="(/h:p/h:span[@data-type='footnote'])[1]">
+      <p>This is the text<span data-type="footnote">And this is the footnote</span></p>
+    </x:context>
+    
+    <x:scenario label="With process.footnotes disabled">
+      <x:context>
+	<x:param name="process.footnotes" select="0"/>
+      </x:context>
+      <x:expect label="Footnote should be copied to output as is">
+	<span data-type="footnote">And this is the footnote</span>
+      </x:expect>
+    </x:scenario>
+
+    <x:scenario label="With process.footnotes enabled">
+      <x:context>
+	<x:param name="process.footnotes" select="1"/>
+      </x:context>
+      <x:expect label="Footnote should be processed to a noteref">
+	<a data-type="noteref" id="..." href="...">
+	  <sup>1</sup>
+	</a>
+      </x:expect>
+    </x:scenario>
+  </x:scenario>
+
+  <x:scenario label="When a footnoteref is matched">
+    <x:context select="(/h:p/h:a[@data-type='footnoteref'])[1]">
+      <p>This is the text<span data-type="footnote">And this is the footnote</span></p>
+      <p>More text<span data-type="footnote" id="best_footnote_ever">Another footnote, yo!</span></p>
+      <p>And now we've got a second paragraph that has a footnoteref here<a data-type="footnoteref" href="#best_footnote_ever"/></p>
+    </x:context>
+    
+    <x:scenario label="With process.footnotes disabled">
+      <x:context>
+	<x:param name="process.footnotes" select="0"/>
+      </x:context>
+      <x:expect label="Footnoteref should be copied to output as is">
+	<a data-type="footnoteref" href="#best_footnote_ever"/>
+      </x:expect>
+    </x:scenario>
+
+    <x:scenario label="With process.footnotes enabled">
+      <x:context>
+	<x:param name="process.footnotes" select="1"/>
+      </x:context>
+      <x:expect label="Footnote should be processed to a noteref">
+	<a data-type="noteref" href="...">
+	  <sup>2</sup>
+	</a>
+      </x:expect>
+    </x:scenario>
+  </x:scenario>
+
+
 </x:description>

--- a/htmlbook-xsl/xspec/elements.xspec
+++ b/htmlbook-xsl/xspec/elements.xspec
@@ -1517,6 +1517,32 @@ sect5:1
       </x:expect>
     </x:scenario>
 
+    <!-- BEGIN NEW -->
+
+    <x:scenario label="With process footnotes enabled and footnote.reset.numbering.at.chapter.level disabled (end-of-section footnote paras)">
+      <x:context select="(/h:section[@id='second_ch']//h:span[@data-type='footnote'])[2]" mode="generate.footnote">
+	<x:param name="process.footnotes" select="1"/>
+	<x:param name="footnote.reset.numbering.at.chapter.level" select="0"/>
+      </x:context>
+      <x:expect label="Footnote should be processed to a para with anchor and proper number">
+	<p data-type="footnote" id="...">
+	  <a href="..."><sup>4</sup></a> Footnote #2 in Chapter #2</p>
+      </x:expect>
+    </x:scenario>
+
+    <x:scenario label="With process footnotes enabled and footnote.reset.numbering.at.chapter.level enabled (end-of-section footnote paras)">
+      <x:context select="(/h:section[@id='second_ch']//h:span[@data-type='footnote'])[2]" mode="generate.footnote">
+	<x:param name="process.footnotes" select="1"/>
+	<x:param name="footnote.reset.numbering.at.chapter.level" select="1"/>
+      </x:context>
+      <x:expect label="Footnote should be processed to a para with anchor and proper number">
+	<p data-type="footnote" id="...">
+	  <a href="..."><sup>2</sup></a> Footnote #2 in Chapter #2</p>
+      </x:expect>
+    </x:scenario>
+
+    <!-- END NEW -->
+
     <x:scenario label="On a footnoteref with process footnotes enabled and footnote.reset.numbering.at.chapter.level disabled">
       <x:context select="(/h:div[@data-type='part']/h:section[@id='third_ch']//h:a[@data-type='footnoteref'])[1]">
 	<x:param name="process.footnotes" select="1"/>

--- a/htmlbook-xsl/xspec/elements.xspec
+++ b/htmlbook-xsl/xspec/elements.xspec
@@ -1437,7 +1437,7 @@ sect5:1
   <!-- Footnote tests -->
   <x:scenario label="When a footnote is matched">
     <x:context select="(/h:p/h:span[@data-type='footnote'])[1]">
-      <p>This is the text<span data-type="footnote">And this is the footnote</span></p>
+      <p>This is the text<span id="fn_id_yo" data-type="footnote">And this is the footnote</span></p>
     </x:context>
     
     <x:scenario label="With process.footnotes disabled">
@@ -1445,7 +1445,7 @@ sect5:1
 	<x:param name="process.footnotes" select="0"/>
       </x:context>
       <x:expect label="Footnote should be copied to output as is">
-	<span data-type="footnote">And this is the footnote</span>
+	<span data-type="footnote" id="fn_id_yo">And this is the footnote</span>
       </x:expect>
     </x:scenario>
 
@@ -1454,11 +1454,149 @@ sect5:1
 	<x:param name="process.footnotes" select="1"/>
       </x:context>
       <x:expect label="Footnote should be processed to a noteref">
-	<a data-type="noteref" id="..." href="...">
+	<a data-type="noteref" id="fn_id_yo-marker" href="#fn_id_yo">
 	  <sup>1</sup>
 	</a>
       </x:expect>
     </x:scenario>
+  </x:scenario>
+
+  <x:scenario label="When footnote is matched">
+    <x:context>
+      <section data-type="chapter" id="first_ch">
+	<h1>First chapter</h1>
+	<p>This chapter has a couple footnotes:</p>
+	<p>Here's the first footnote<span  data-type="footnote">Footnote #1 in Chapter #1</span></p>
+	<p>Here's the second footnote<span data-type="footnote">Footnote #2 in Chapter #1</span></p>
+      </section>
+      <section data-type="chapter" id="second_ch">
+	<h1>Second chapter</h1>
+	<p>This chapter also has a couple footnotes:</p>
+	<p>Here's the first footnote<span data-type="footnote">Footnote #1 in Chapter #2</span></p>
+	<p>Here's the second footnote<span data-type="footnote">Footnote #2 in Chapter #2</span></p>
+      </section>
+      <div data-type="part">
+	<h1>Here's a part</h1>
+	<section data-type="chapter" id="third_ch">
+	  <h1>Third chapter</h1>
+	  <p>This chapter also has a couple footnotes:</p>
+	  <p>Here's the first footnote<span data-type="footnote">Footnote #1 in Chapter #2</span></p>
+	  <p>Here's the second footnote<span id="second_part_fn" data-type="footnote">Footnote #2 in Chapter #2</span></p>
+	  <p>Here's a footnoteref to the second footnote<a data-type="footnoteref" href="#second_part_fn"/></p>
+	</section>
+      </div>
+      <section data-type="appendix" id="the_app">
+	<h1>The Appendix</h1>
+	<p>The appendix also has a couple footnotes:</p>
+	<p>Here's the first footnote<span data-type="footnote">Footnote #1 in the Appendix</span></p>
+	<p>Here's the second footnote<span data-type="footnote">Footnote #2 in the Appendix</span></p>
+      </section>
+    </x:context>
+
+    <x:scenario label="With process footnotes enabled and footnote.reset.numbering.at.chapter.level disabled">
+      <x:context select="(/h:section[@id='second_ch']//h:span[@data-type='footnote'])[2]">
+	<x:param name="process.footnotes" select="1"/>
+	<x:param name="footnote.reset.numbering.at.chapter.level" select="0"/>
+      </x:context>
+      <x:expect label="Footnote should be processed to a noteref with proper number">
+	<a data-type="noteref" id="..." href="...">
+	  <sup>4</sup>
+	</a>
+      </x:expect>
+    </x:scenario>
+
+    <x:scenario label="With process footnotes enabled and footnote.reset.numbering.at.chapter.level enabled">
+      <x:context select="(/h:section[@id='second_ch']//h:span[@data-type='footnote'])[2]">
+	<x:param name="process.footnotes" select="1"/>
+	<x:param name="footnote.reset.numbering.at.chapter.level" select="1"/>
+      </x:context>
+      <x:expect label="Footnote should be processed to a noteref with proper number">
+	<a data-type="noteref" id="..." href="...">
+	  <sup>2</sup>
+	</a>
+      </x:expect>
+    </x:scenario>
+
+    <x:scenario label="On a footnoteref with process footnotes enabled and footnote.reset.numbering.at.chapter.level disabled">
+      <x:context select="(/h:div[@data-type='part']/h:section[@id='third_ch']//h:a[@data-type='footnoteref'])[1]">
+	<x:param name="process.footnotes" select="1"/>
+	<x:param name="footnote.reset.numbering.at.chapter.level" select="0"/>
+      </x:context>
+      <x:expect label="Footnote should be processed to a noteref with proper number">
+	<a data-type="noteref" href="...">
+	  <sup>6</sup>
+	</a>
+      </x:expect>
+    </x:scenario>
+
+    <x:scenario label="On a footnoteref with process footnotes enabled and footnote.reset.numbering.at.chapter.level enabled">
+      <x:context select="(/h:div[@data-type='part']/h:section[@id='third_ch']//h:a[@data-type='footnoteref'])[1]">
+	<x:param name="process.footnotes" select="1"/>
+	<x:param name="footnote.reset.numbering.at.chapter.level" select="1"/>
+      </x:context>
+      <x:expect label="Footnote should be processed to a noteref with proper number">
+	<a data-type="noteref" href="...">
+	  <sup>2</sup>
+	</a>
+      </x:expect>
+    </x:scenario>
+    
+    <x:scenario label="In numbering mode with footnote.reset.numbering.at.chapter.level disabled (first chapter)">
+      <x:context select="(/h:section[@id='first_ch']//h:span[@data-type='footnote'])[2]" mode="footnote.number">
+	<x:param name="footnote.reset.numbering.at.chapter.level" select="0"/>
+      </x:context>
+      <x:expect label="The correct number should be generated">2</x:expect>
+    </x:scenario>
+
+    <x:scenario label="In numbering mode with footnote.reset.numbering.at.chapter.level disabled (second chapter)">
+      <x:context select="(/h:section[@id='second_ch']//h:span[@data-type='footnote'])[2]" mode="footnote.number">
+	<x:param name="footnote.reset.numbering.at.chapter.level" select="0"/>
+      </x:context>
+      <x:expect label="The correct number should be generated">4</x:expect>
+    </x:scenario>
+
+    <x:scenario label="In numbering mode with footnote.reset.numbering.at.chapter.level disabled (third chapter; in part)">
+      <x:context select="(/h:div[@data-type='part']/h:section[@id='third_ch']//h:span[@data-type='footnote'])[1]" mode="footnote.number">
+	<x:param name="footnote.reset.numbering.at.chapter.level" select="0"/>
+      </x:context>
+      <x:expect label="The correct number should be generated">5</x:expect>
+    </x:scenario>
+
+    <x:scenario label="In numbering mode with footnote.reset.numbering.at.chapter.level disabled (appendix)">
+      <x:context select="(/h:section[@id='the_app']//h:span[@data-type='footnote'])[1]" mode="footnote.number">
+	<x:param name="footnote.reset.numbering.at.chapter.level" select="0"/>
+      </x:context>
+      <x:expect label="The correct number should be generated">7</x:expect>
+    </x:scenario>
+
+    <x:scenario label="In numbering mode with footnote.reset.numbering.at.chapter.level enabled (first chapter)">
+      <x:context select="(/h:section[@id='first_ch']//h:span[@data-type='footnote'])[2]" mode="footnote.number">
+	<x:param name="footnote.reset.numbering.at.chapter.level" select="1"/>
+      </x:context>
+      <x:expect label="The correct number should be generated">2</x:expect>
+    </x:scenario>
+
+    <x:scenario label="In numbering mode with footnote.reset.numbering.at.chapter.level enabled (second chapter)">
+      <x:context select="(/h:section[@id='second_ch']//h:span[@data-type='footnote'])[2]" mode="footnote.number">
+	<x:param name="footnote.reset.numbering.at.chapter.level" select="1"/>
+      </x:context>
+      <x:expect label="The correct number should be generated">2</x:expect>
+    </x:scenario>
+
+    <x:scenario label="In numbering mode with footnote.reset.numbering.at.chapter.level enabled (third chapter; in part)">
+      <x:context select="(/h:div[@data-type='part']/h:section[@id='third_ch']//h:span[@data-type='footnote'])[1]" mode="footnote.number">
+	<x:param name="footnote.reset.numbering.at.chapter.level" select="1"/>
+      </x:context>
+      <x:expect label="The correct number should be generated">1</x:expect>
+    </x:scenario>
+
+    <x:scenario label="In numbering mode with footnote.reset.numbering.at.chapter.level enabled (appendix)">
+      <x:context select="(/h:section[@id='the_app']//h:span[@data-type='footnote'])[1]" mode="footnote.number">
+	<x:param name="footnote.reset.numbering.at.chapter.level" select="1"/>
+      </x:context>
+      <x:expect label="The correct number should be generated">1</x:expect>
+    </x:scenario>
+
   </x:scenario>
 
   <x:scenario label="When a footnoteref is matched">

--- a/htmlbook-xsl/xspec/elements.xspec
+++ b/htmlbook-xsl/xspec/elements.xspec
@@ -1517,8 +1517,6 @@ sect5:1
       </x:expect>
     </x:scenario>
 
-    <!-- BEGIN NEW -->
-
     <x:scenario label="With process footnotes enabled and footnote.reset.numbering.at.chapter.level disabled (end-of-section footnote paras)">
       <x:context select="(/h:section[@id='second_ch']//h:span[@data-type='footnote'])[2]" mode="generate.footnote">
 	<x:param name="process.footnotes" select="1"/>
@@ -1540,8 +1538,6 @@ sect5:1
 	  <a href="..."><sup>2</sup></a> Footnote #2 in Chapter #2</p>
       </x:expect>
     </x:scenario>
-
-    <!-- END NEW -->
 
     <x:scenario label="On a footnoteref with process footnotes enabled and footnote.reset.numbering.at.chapter.level disabled">
       <x:context select="(/h:div[@data-type='part']/h:section[@id='third_ch']//h:a[@data-type='footnoteref'])[1]">


### PR DESCRIPTION
Added new parameter `footnote.reset.numbering.at.chapter.level`. When enabled (set to 1), then footnote numbering resets to 1 at the beginning of chapter-level elements (elements that are children of `<body>` or Parts: chapter, appendix, preface, etc.). Otherwise footnote numbering does not reset.