### PR TITLE
Fixes to footnote handling

### DIFF
--- a/htmlbook-xsl/elements.xsl
+++ b/htmlbook-xsl/elements.xsl
@@ -288,6 +288,7 @@
 
   <xsl:template match="h:span[@data-type='footnote']" mode="footnote.marker" name="footnote-marker">
     <xsl:param name="footnote.reset.numbering.at.chapter.level" select="$footnote.reset.numbering.at.chapter.level"/>
+    <sup>
     <a data-type="noteref">
       <xsl:attribute name="id">
 	<xsl:call-template name="object.id"/>
@@ -296,14 +297,13 @@
       <xsl:attribute name="href">
 	<xsl:call-template name="href.target"/>
       </xsl:attribute>
-      <sup>
 	<!-- Use numbers for footnotes -->
 	<!-- ToDo: Parameterize for numeration type and/or symbols? -->
 	<xsl:apply-templates select="." mode="footnote.number">
 	  <xsl:with-param name="footnote.reset.numbering.at.chapter.level" select="$footnote.reset.numbering.at.chapter.level"/>
 	</xsl:apply-templates>
-      </sup>
     </a>
+    </sup>
   </xsl:template>
 
   <!-- Handling for footnoterefs a la DocBook (cross-references to an existing footnote) -->
@@ -322,18 +322,18 @@
 	    <!-- Switch the context node to that of the referenced footnote -->
 	    <xsl:for-each select="$referenced-footnote[1]">
 	      <!-- Same general handling as regular footnote markers, except footnoterefs don't get ids -->
+	      <sup>
 	      <a data-type="noteref">
 		<xsl:attribute name="href">
 		  <xsl:call-template name="href.target"/>
 		</xsl:attribute>
-		<sup>
 		  <!-- Use numbers for footnotes -->
 		  <!-- ToDo: Parameterize for numeration type and/or symbols? -->
 		  <xsl:apply-templates select="." mode="footnote.number">
 		    <xsl:with-param name="footnote.reset.numbering.at.chapter.level" select="$footnote.reset.numbering.at.chapter.level"/>
 		  </xsl:apply-templates>
-		</sup>
 	  </a>
+	  </sup>
 	    </xsl:for-each>
 	  </xsl:when>
 	  <xsl:otherwise>
@@ -403,19 +403,19 @@
       <xsl:attribute name="id">
 	<xsl:call-template name="object.id"/>
       </xsl:attribute>
+      <sup>
       <a>
 	<xsl:attribute name="href">
 	  <xsl:call-template name="href.target"/>
 	  <xsl:text>-marker</xsl:text>
 	</xsl:attribute>
-	<sup>
 	  <!-- Use numbers for footnotes -->
 	  <!-- ToDo: Parameterize for numeration type and/or symbols? -->
 	  <xsl:apply-templates select="." mode="footnote.number">
 	    <xsl:with-param name="footnote.reset.numbering.at.chapter.level" select="$footnote.reset.numbering.at.chapter.level"/>
 	  </xsl:apply-templates>
-	</sup>
       </a>
+      </sup>
       <xsl:text> </xsl:text>
       <xsl:apply-templates/>
     </p>

--- a/htmlbook-xsl/xspec/elements.xspec
+++ b/htmlbook-xsl/xspec/elements.xspec
@@ -1454,9 +1454,9 @@ sect5:1
 	<x:param name="process.footnotes" select="1"/>
       </x:context>
       <x:expect label="Footnote should be processed to a noteref">
-	<a data-type="noteref" id="fn_id_yo-marker" href="#fn_id_yo">
-	  <sup>1</sup>
-	</a>
+	<sup>
+	<a data-type="noteref" id="fn_id_yo-marker" href="#fn_id_yo">1</a>
+	</sup>
       </x:expect>
     </x:scenario>
   </x:scenario>
@@ -1502,9 +1502,9 @@ sect5:1
 	<x:param name="footnote.reset.numbering.at.chapter.level" select="0"/>
       </x:context>
       <x:expect label="Footnote should be processed to a noteref with proper number">
-	<a data-type="noteref" id="..." href="...">
-	  <sup>4</sup>
-	</a>
+	<sup>
+	<a data-type="noteref" id="..." href="...">4</a>
+	</sup>
       </x:expect>
     </x:scenario>
 
@@ -1514,9 +1514,9 @@ sect5:1
 	<x:param name="footnote.reset.numbering.at.chapter.level" select="1"/>
       </x:context>
       <x:expect label="Footnote should be processed to a noteref with proper number">
-	<a data-type="noteref" id="..." href="...">
-	  <sup>2</sup>
-	</a>
+	<sup>
+	<a data-type="noteref" id="..." href="...">2</a>
+	</sup>
       </x:expect>
     </x:scenario>
 
@@ -1527,7 +1527,7 @@ sect5:1
       </x:context>
       <x:expect label="Footnote should be processed to a para with anchor and proper number">
 	<p data-type="footnote" id="...">
-	  <a href="..."><sup>4</sup></a> Footnote #2 in Chapter #2</p>
+	  <sup><a href="...">4</a></sup> Footnote #2 in Chapter #2</p>
       </x:expect>
     </x:scenario>
 
@@ -1538,7 +1538,7 @@ sect5:1
       </x:context>
       <x:expect label="Footnote should be processed to a para with anchor and proper number">
 	<p data-type="footnote" id="...">
-	  <a href="..."><sup>2</sup></a> Footnote #2 in Chapter #2</p>
+	  <sup><a href="...">2</a></sup> Footnote #2 in Chapter #2</p>
       </x:expect>
     </x:scenario>
 
@@ -1548,9 +1548,9 @@ sect5:1
 	<x:param name="footnote.reset.numbering.at.chapter.level" select="0"/>
       </x:context>
       <x:expect label="Footnote should be processed to a noteref with proper number">
-	<a data-type="noteref" href="...">
-	  <sup>8</sup>
-	</a>
+	<sup>
+	<a data-type="noteref" href="...">8</a>
+	</sup>
       </x:expect>
     </x:scenario>
 
@@ -1560,9 +1560,9 @@ sect5:1
 	<x:param name="footnote.reset.numbering.at.chapter.level" select="1"/>
       </x:context>
       <x:expect label="Footnote should be processed to a noteref with proper number">
-	<a data-type="noteref" href="...">
-	  <sup>2</sup>
-	</a>
+	<sup>
+	<a data-type="noteref" href="...">2</a>
+	</sup>
       </x:expect>
     </x:scenario>
     
@@ -1659,9 +1659,9 @@ sect5:1
 	<x:param name="process.footnotes" select="1"/>
       </x:context>
       <x:expect label="Footnote should be processed to a noteref">
-	<a data-type="noteref" href="...">
-	  <sup>2</sup>
-	</a>
+	<sup>
+	<a data-type="noteref" href="...">2</a>
+	</sup>
       </x:expect>
     </x:scenario>
   </x:scenario>

--- a/htmlbook-xsl/xspec/elements.xspec
+++ b/htmlbook-xsl/xspec/elements.xspec
@@ -1649,8 +1649,8 @@ sect5:1
       <x:context>
 	<x:param name="process.footnotes" select="0"/>
       </x:context>
-      <x:expect label="Footnoteref should be copied to output as is">
-	<a data-type="footnoteref" href="#best_footnote_ever"/>
+      <x:expect label="Footnoteref should be processed to marker with correct number">
+	<sup class="footnoteref">2</sup>
       </x:expect>
     </x:scenario>
 

--- a/htmlbook-xsl/xspec/epub.xspec
+++ b/htmlbook-xsl/xspec/epub.xspec
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               xmlns:functx="http://www.functx.com"
+	       xmlns="http://www.w3.org/1999/xhtml"
+	       xmlns:dc="http://purl.org/dc/elements/1.1/"
+	       xmlns:ncx="http://www.daisy.org/z3986/2005/ncx/"
+	       xmlns:dcterms="http://purl.org/dc/terms/"
+	       xmlns:opf="http://www.idpf.org/2007/opf"
+	       xmlns:h="http://www.w3.org/1999/xhtml"
+	       xmlns:e="http://github.com/oreillymedia/epubrenderer"
+	       xmlns:epub="http://www.idpf.org/2007/ops"
+               stylesheet="../epub.xsl">
+
+  <!-- Test suite for epub.xsl -->
+
+  <x:scenario label="When a data-type attribute is matched">
+    <x:context select="(/h:aside)[1]">
+      <aside data-type="sidebar">
+	<h5>Sidebar title</h5>
+	<p>Some text</p>
+      </aside>
+    </x:context>
+    <x:expect label="It should be propagated to output as is, and also in a epub:type attribute (if part of the EPUB SSV)">
+      <aside data-type="sidebar" epub:type="sidebar">...</aside>
+    </x:expect>
+  </x:scenario>
+
+</x:description>

--- a/htmlbook-xsl/xspec/ncx.xspec
+++ b/htmlbook-xsl/xspec/ncx.xspec
@@ -38,6 +38,14 @@ sect5:none
     <x:expect label="It should have the standard ncx root element">
       <ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1">...</ncx>
     </x:expect>
+  	
+  	<x:expect label="It should have the book title in a docTitle element" test="exists(/ncx:ncx/ncx:docTitle[. = 'Infinite Jest'])"/>
+  	
+  	<x:expect label="It should have a navMap with navPoint children for TOC elements" test="exists(/ncx:ncx/ncx:navMap[ncx:navPoint])"/>
+  	
+  	<x:expect label="navPoints should have playOrder attributes in consecutive order" 
+  		test="not(exists(//ncx:navPoint[not(@playOrder)])) and
+  		count((//ncx:navPoint)[position() = @playOrder]) = count((//ncx:navPoint))"/>
     
     <x:scenario label="With generate.cover.html disabled">
       <x:call>
@@ -63,14 +71,7 @@ sect5:none
       </x:scenario>
     </x:pending>
     
-    <x:expect label="It should have the book title in a docTitle element" test="exists(/ncx:ncx/ncx:docTitle[. = 'Infinite Jest'])"/>
-    
-    <x:expect label="It should have a navMap with navPoint children for TOC elements" test="exists(/ncx:ncx/ncx:navMap[ncx:navPoint])"/>
-
-    <x:expect label="navPoints should have playOrder attributes in consecutive order" 
-	      test="not(exists(//ncx:navPoint[not(@playOrder)])) and
-		    count((//ncx:navPoint)[position() = @playOrder]) = count((//ncx:navPoint))"/>
-  </x:scenario>
+      </x:scenario>
 
     <x:scenario label="When a book section/div is matched in ncx.toc.gen mode">
       <x:context mode="ncx.toc.gen">
@@ -155,6 +156,10 @@ sect5:none
       <x:expect label="A navLabel element should be generated with properly formatted heading text" 
 		test="count(ncx:navPoint/ncx:navLabel[contains(., 'Tables of Crucial Data')]) = 1"/>
 
+    	<!-- More robust testing here for src attribute value might be nice. -->
+    	<x:expect label="A navPoint element should contain a content element with a src attribute"
+    		test="exists(ncx:navPoint/ncx:content[@src])"/>
+
       <x:scenario label="with $ncx.toc.include.label enabled">
 	<x:call>
 	  <x:param name="ncx.toc.include.labels" select="1"/>
@@ -185,10 +190,6 @@ sect5:none
 	<x:expect label="A navLabel's text content *should not* contain any inline elements"
 		  test="not(exists(ncx:navPoint/ncx:navLabel/ncx:text/*))"/>
       </x:scenario>
-
-      <!-- More robust testing here for src attribute value might be nice. -->
-      <x:expect label="A navPoint element should contain a content element with a src attribute"
-		test="exists(ncx:navPoint/ncx:content[@src])"/>
 
     </x:scenario>
 

--- a/htmlbook-xsl/xspec/opf.xspec
+++ b/htmlbook-xsl/xspec/opf.xspec
@@ -58,12 +58,7 @@ UbuntuMono-Regular.otf
 
   <x:scenario label="When generate.opf is run">
     <x:call template="generate.opf.content"/>
-    <x:scenario label="with generate.guide disabled">
-      <x:call>
-	<x:param name="generate.guide" select="0"/>
-      </x:call>
-      <x:expect test="not(exists(/opf:package/opf:guide))"/>
-    </x:scenario>
+
     <x:expect label="A package root element should be generated with the proper namespaces">
       <package xmlns="http://www.idpf.org/2007/opf" 
 	       xmlns:opf="http://www.idpf.org/2007/opf"
@@ -77,6 +72,12 @@ UbuntuMono-Regular.otf
     <x:expect label="The OPF package should contain a manifest element" test="exists(/opf:package/opf:manifest)"/>
     <x:expect label="The OPF package should contain a spine element" test="exists(/opf:package/opf:spine)"/>
     <x:expect label="The OPF package should contain a guide element by default" test="exists(/opf:package/opf:guide)"/>
+  	<x:scenario label="with generate.guide disabled">
+  		<x:call>
+  			<x:param name="generate.guide" select="0"/>
+  		</x:call>
+  		<x:expect label="The OPF package should not contain a guide element" test="not(exists(/opf:package/opf:guide))"/>
+  	</x:scenario>
   </x:scenario>
 
   <x:scenario label="When opf.manifest is run">


### PR DESCRIPTION
Two fixes for footnote handling:

* When process.footnotes is enabled, nest `<a>` elements in `<sup>` for better results when CSS styling.

* When process.footnotes is disabled, still generate marker numbers for "footnoteref" elements `<a data-type="footnoteref">`