### PR TITLE
Generalizing external asset handling for EPUB OPF generation

### DIFF
--- a/htmlbook-xsl/epub.xsl
+++ b/htmlbook-xsl/epub.xsl
@@ -204,16 +204,16 @@
   <!-- ID to use in the manifest for the CSS (if $css.filename is nonempty) -->
   <xsl:param name="css.id">epub-css</xsl:param>
 
-  <!-- List fonts to be embedded here: place each font on a separate line -->
-  <xsl:param name="embedded.fonts.list">DejaVuSerif.otf
+  <!-- List "external assets" (assets not referenced in source, like fonts, CSS url()s)
+       to be embedded here: place each asset on a separate line 
+       Filenames should be relative paths from OPF directory to location of asset
+  -->
+  <xsl:param name="external.assets.list">DejaVuSerif.otf
 DejaVuSans-Bold.otf
 UbuntuMono-Regular.otf
 UbuntuMono-Bold.otf
 UbuntuMono-BoldItalic.otf
 UbuntuMono-Italic.otf</xsl:param>
-
-  <!-- Directory to place embedded fonts, relative to content directory; leave blank to put in root content dir (e.g., in "OEBPS" dir) -->
-  <xsl:param name="embedded.fonts.directory"/>
 
   <!-- Useful for EPUB 2 backward compatibility. Setting to 1 will turn on EPUB2-compatible elements, 
        which means that HTML5 structural semantic elements

--- a/htmlbook-xsl/opf.xsl
+++ b/htmlbook-xsl/opf.xsl
@@ -32,59 +32,59 @@
     <xsl:value-of select="$opf.filename"/>
   </xsl:variable>
       
-  <!-- Convert $embedded.fonts.list to XML for easier parsing -->
-  <xsl:variable name="embedded.fonts.list.xml">
-    <xsl:call-template name="get.fonts.xml"/>
+  <!-- Convert $external.assets.list to XML for easier parsing -->
+  <xsl:variable name="external.assets.list.xml">
+    <xsl:call-template name="get.external.assets.xml"/>
   </xsl:variable>
 
-  <!-- Reformat fonts list as XML that can be parsed -->
-  <xsl:template name="get.fonts.xml">
-    <xsl:param name="fonts.to.process" select="$embedded.fonts.list"/>
+  <!-- Reformat assets list as XML that can be parsed -->
+  <xsl:template name="get.external.assets.xml">
+    <xsl:param name="assets.to.process" select="$external.assets.list"/>
     <xsl:param name="first.call" select="1"/>
     <xsl:choose>
       <xsl:when test="$first.call = 1">
-	<e:fonts>
-	  <xsl:call-template name="get.fonts.xml">
-	    <xsl:with-param name="fonts.to.process" select="$fonts.to.process"/>
+	<e:assets>
+	  <xsl:call-template name="get.external.assets.xml">
+	    <xsl:with-param name="assets.to.process" select="$assets.to.process"/>
 	    <xsl:with-param name="first.call" select="0"/>
 	  </xsl:call-template>
-	</e:fonts>
+	</e:assets>
       </xsl:when>
       <xsl:otherwise>
 	<xsl:choose>
-	  <xsl:when test="normalize-space(substring-before($fonts.to.process, '&#x0A;')) != ''">
-	    <xsl:variable name="font-filename">
-	      <xsl:value-of select="normalize-space(substring-before($fonts.to.process, '&#x0A;'))"/>
+	  <xsl:when test="normalize-space(substring-before($assets.to.process, '&#x0A;')) != ''">
+	    <xsl:variable name="asset-filename">
+	      <xsl:value-of select="normalize-space(substring-before($assets.to.process, '&#x0A;'))"/>
 	    </xsl:variable>
-	    <xsl:variable name="font-extension">
-	      <xsl:value-of select="normalize-space(substring-after($font-filename, '.'))"/>
+	    <xsl:variable name="asset-extension">
+	      <xsl:value-of select="normalize-space(substring-after($asset-filename, '.'))"/>
 	    </xsl:variable>
-	    <xsl:variable name="font-mimetype">
+	    <xsl:variable name="asset-mimetype">
 	      <xsl:call-template name="get-mimetype-from-file-extension">
-		<xsl:with-param name="file-extension" select="$font-extension"/>
+		<xsl:with-param name="file-extension" select="$asset-extension"/>
 	      </xsl:call-template>
 	    </xsl:variable>
-	    <e:font filename="{$font-filename}" mimetype="{$font-mimetype}"/>
-	    <xsl:if test="normalize-space(substring-after($fonts.to.process, '&#x0A;')) != ''">
-	      <xsl:call-template name="get.fonts.xml">
-		<xsl:with-param name="fonts.to.process" select="substring-after($fonts.to.process, '&#x0A;')"/>
+	    <e:asset filename="{$asset-filename}" mimetype="{$asset-mimetype}"/>
+	    <xsl:if test="normalize-space(substring-after($assets.to.process, '&#x0A;')) != ''">
+	      <xsl:call-template name="get.external.assets.xml">
+		<xsl:with-param name="assets.to.process" select="substring-after($assets.to.process, '&#x0A;')"/>
 		<xsl:with-param name="first.call" select="0"/>
 	      </xsl:call-template>
 	    </xsl:if>
 	  </xsl:when>
-	  <xsl:when test="normalize-space($fonts.to.process) != ''">
-	    <xsl:variable name="font-filename">
-	      <xsl:value-of select="normalize-space($fonts.to.process)"/>
+	  <xsl:when test="normalize-space($assets.to.process) != ''">
+	    <xsl:variable name="asset-filename">
+	      <xsl:value-of select="normalize-space($assets.to.process)"/>
 	    </xsl:variable>
-	    <xsl:variable name="font-extension">
-	      <xsl:value-of select="normalize-space(substring-after($font-filename, '.'))"/>
+	    <xsl:variable name="asset-extension">
+	      <xsl:value-of select="normalize-space(substring-after($asset-filename, '.'))"/>
 	    </xsl:variable>
-	    <xsl:variable name="font-mimetype">
+	    <xsl:variable name="asset-mimetype">
 	      <xsl:call-template name="get-mimetype-from-file-extension">
-		<xsl:with-param name="file-extension" select="$font-extension"/>
+		<xsl:with-param name="file-extension" select="$asset-extension"/>
 	      </xsl:call-template>
 	    </xsl:variable>
-	    <e:font filename="{$font-filename}" mimetype="{$font-mimetype}"/>
+	    <e:asset filename="{$asset-filename}" mimetype="{$asset-mimetype}"/>
 	  </xsl:when>
 	</xsl:choose>
       </xsl:otherwise>
@@ -193,9 +193,9 @@
 	  </xsl:attribute>
 	</item>
       </xsl:if>
-      <!-- Add any embedded fonts to EPUB manifest, if they will be included in the EPUB package -->
-      <xsl:for-each select="exsl:node-set($embedded.fonts.list.xml)//e:font">
-	<item id="{concat('epub.embedded.font.', position())}" href="{@filename}" media-type="{@mimetype}"/>
+      <!-- Add any embedded assets to EPUB manifest, if they will be included in the EPUB package -->
+      <xsl:for-each select="exsl:node-set($external.assets.list.xml)//e:asset">
+	<item id="{concat('epub.embedded.asset.', position())}" href="{@filename}" media-type="{@mimetype}"/>
       </xsl:for-each>
       <!-- Add cover to manifest, if present -->
       <xsl:if test="$generate.cover.html = 1">

--- a/htmlbook-xsl/xspec/opf.xspec
+++ b/htmlbook-xsl/xspec/opf.xspec
@@ -38,20 +38,30 @@ DejaVuSans-Bold.otf
 UbuntuMono-Regular.otf
 UbuntuMono-Bold.otf
 UbuntuMono-BoldItalic.otf
-UbuntuMono-Italic.otf</x:param>
+UbuntuMono-Italic.otf
+images/puppy.png
+images/kitkat.jpg</x:param>
   
   <x:scenario label="When get.external.assets.xml is run">
     <x:call template="get.external.assets.xml">
       <x:param name="assets.to.process">DejaVuSerif.otf
 DejaVuSerif.ttf
+boston.gif
+pencil.jpg
 UbuntuMono-Regular.otf
+css_images/puppy.png
+css_images/pizza.svg
 </x:param>
     </x:call>
     <x:expect label="it should return an XML-formatted lists of assets with proper mimetypes">
       <e:assets>
 	<e:asset filename="DejaVuSerif.otf" mimetype="application/vnd.ms-opentype"/>
 	<e:asset filename="DejaVuSerif.ttf" mimetype="font/truetype"/>
+	<e:asset filename="boston.gif" mimetype="image/gif"/>
+	<e:asset filename="pencil.jpg" mimetype="image/jpeg"/>
 	<e:asset filename="UbuntuMono-Regular.otf" mimetype="application/vnd.ms-opentype"/>
+	<e:asset filename="css_images/puppy.png" mimetype="image/png"/>
+	<e:asset filename="css_images/pizza.svg" mimetype="image/svg+xml"/>
       </e:assets>
     </x:expect>
   </x:scenario>
@@ -83,12 +93,14 @@ UbuntuMono-Regular.otf
   <x:scenario label="When opf.manifest is run">
     <x:call template="opf.manifest"/>
     <!-- Based on font list specified in global param $external.assets.list -->
-    <x:expect label="there should be items for each font" test="exists(/opf:manifest/opf:item[@href='DejaVuSerif.otf']) and
+    <x:expect label="there should be items for each external asset" test="exists(/opf:manifest/opf:item[@href='DejaVuSerif.otf']) and
 								exists(/opf:manifest/opf:item[@href='DejaVuSans-Bold.otf']) and
 								exists(/opf:manifest/opf:item[@href='UbuntuMono-Regular.otf']) and
 								exists(/opf:manifest/opf:item[@href='UbuntuMono-Bold.otf']) and
 								exists(/opf:manifest/opf:item[@href='UbuntuMono-BoldItalic.otf']) and
-								exists(/opf:manifest/opf:item[@href='UbuntuMono-Italic.otf'])"/>
+								exists(/opf:manifest/opf:item[@href='UbuntuMono-Italic.otf']) and
+								exists(/opf:manifest/opf:item[@href='images/puppy.png']) and
+								exists(/opf:manifest/opf:item[@href='images/kitkat.jpg'])"/>
     <x:scenario label="with NCX generation enabled">
       <x:call>
 	<x:param name="generate.ncx.toc" select="1"/>

--- a/htmlbook-xsl/xspec/opf.xspec
+++ b/htmlbook-xsl/xspec/opf.xspec
@@ -33,26 +33,26 @@
   <x:param name="root.chunk.filename" select="'index.html'"/>
   <x:param name="epub.cover.image.id" select="'bookcoverimage'"/>
 
-  <x:param name="embedded.fonts.list">DejaVuSerif.otf
+  <x:param name="external.assets.list">DejaVuSerif.otf
 DejaVuSans-Bold.otf
 UbuntuMono-Regular.otf
 UbuntuMono-Bold.otf
 UbuntuMono-BoldItalic.otf
 UbuntuMono-Italic.otf</x:param>
   
-  <x:scenario label="When get.fonts.xml is run">
-    <x:call template="get.fonts.xml">
-      <x:param name="fonts.to.process">DejaVuSerif.otf
+  <x:scenario label="When get.external.assets.xml is run">
+    <x:call template="get.external.assets.xml">
+      <x:param name="assets.to.process">DejaVuSerif.otf
 DejaVuSerif.ttf
 UbuntuMono-Regular.otf
 </x:param>
     </x:call>
-    <x:expect label="it should return an XML-formatted lists of fonts with proper mimetypes">
-      <e:fonts>
-	<e:font filename="DejaVuSerif.otf" mimetype="application/vnd.ms-opentype"/>
-	<e:font filename="DejaVuSerif.ttf" mimetype="font/truetype"/>
-	<e:font filename="UbuntuMono-Regular.otf" mimetype="application/vnd.ms-opentype"/>
-      </e:fonts>
+    <x:expect label="it should return an XML-formatted lists of assets with proper mimetypes">
+      <e:assets>
+	<e:asset filename="DejaVuSerif.otf" mimetype="application/vnd.ms-opentype"/>
+	<e:asset filename="DejaVuSerif.ttf" mimetype="font/truetype"/>
+	<e:asset filename="UbuntuMono-Regular.otf" mimetype="application/vnd.ms-opentype"/>
+      </e:assets>
     </x:expect>
   </x:scenario>
 
@@ -82,7 +82,7 @@ UbuntuMono-Regular.otf
 
   <x:scenario label="When opf.manifest is run">
     <x:call template="opf.manifest"/>
-    <!-- Based on font list specified in global param $embedded.fonts.list -->
+    <!-- Based on font list specified in global param $external.assets.list -->
     <x:expect label="there should be items for each font" test="exists(/opf:manifest/opf:item[@href='DejaVuSerif.otf']) and
 								exists(/opf:manifest/opf:item[@href='DejaVuSans-Bold.otf']) and
 								exists(/opf:manifest/opf:item[@href='UbuntuMono-Regular.otf']) and


### PR DESCRIPTION
Generalized `embedded.fonts.list` param and  `get.fonts.xml` template to `external.assets.list` param and `get.external.assets.xml`, respectively, to enable their use for both fonts and other external assets (e.g., image assets referenced in CSS url()s)