### PR TITLE
Additional <tfoot> handling for table footnotes

### DIFF
--- a/htmlbook-xsl/common.xsl
+++ b/htmlbook-xsl/common.xsl
@@ -683,4 +683,23 @@
     </xsl:choose>
   </xsl:template>
 
+  <!-- Infer the number of columns in a table -->
+  <!-- ToDo: More sophistication needed? -->
+  <xsl:template match="h:table" mode="number.of.table.columns" name="number-of-table-columns">
+    <xsl:choose>
+       <!-- If there is a single colgroup child of table element, with a span on it, use that -->
+      <xsl:when test="h:colgroup[not(preceding-sibling::h:colgroup or following-sibling::h:colgroup) and @span]">
+	<xsl:value-of select="h:colgroup[1]/@span"/>
+      </xsl:when>
+      <!-- Otherwise, if there's a tbody, use the number of columns in the first row of the last tbody -->
+      <xsl:when test="h:tbody">
+	<xsl:value-of select="count(h:tbody[last()]/h:tr[1]/h:td)"/>
+      </xsl:when>
+      <!-- Otherwise, use the first row -->
+      <xsl:otherwise>
+	<xsl:value-of select="count(h:tr[1]/h:td)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
 </xsl:stylesheet> 

--- a/htmlbook-xsl/elements.xsl
+++ b/htmlbook-xsl/elements.xsl
@@ -146,12 +146,15 @@
   <!-- Custom handling for tables that have footnotes -->
   <xsl:template match="h:table[descendant::h:span[@data-type='footnote']]">
     <xsl:param name="process.footnotes" select="$process.footnotes"/>
+    <xsl:variable name="number-of-table-columns">
+      <xsl:apply-templates select="." mode="number.of.table.columns"/>
+    </xsl:variable>
     <xsl:copy>
       <xsl:apply-templates select="@*|node()"/>
       <!-- Put table footnotes in a tfoot -->
       <tfoot class="footnotes">
 	<tr>
-	  <td>
+	  <td colspan="{$number-of-table-columns}">
 	    <xsl:for-each select="descendant::h:span[@data-type='footnote']">
 	      <xsl:apply-templates select="." mode="generate.footnote"/>
 	    </xsl:for-each>

--- a/htmlbook-xsl/xspec/common.xspec
+++ b/htmlbook-xsl/xspec/common.xspec
@@ -1366,4 +1366,198 @@ sect1
     <x:expect label="It should return 'false'">0</x:expect>
   </x:scenario>
 
+  <!-- Table column calculations -->
+
+  <x:scenario label="When matching a table with a colgroup">
+    <x:context mode="number.of.table.columns">
+      <table>
+	<colgroup span="2"/>
+	<tbody>
+	  <tr>
+	    <td>First</td>
+	    <td>Second</td>
+	  </tr>
+	  <tr>
+	    <td>Third</td>
+	    <td>Fourth</td>
+	  </tr>
+	</tbody>
+      </table>
+    </x:context>
+    <!-- check the result -->
+    <x:expect label="The colgroup span should be returned as the number of columns">2</x:expect>
+  </x:scenario>
+
+  <x:scenario label="When matching a table with a colgroup">
+    <x:context mode="number.of.table.columns">
+      <table>
+	<colgroup span="5"/>
+	<tbody>
+	  <tr>
+	    <td>First</td>
+	    <td>Second</td>
+	  </tr>
+	  <tr>
+	    <td>Third</td>
+	    <td>Fourth</td>
+	  </tr>
+	</tbody>
+      </table>
+    </x:context>
+    <!-- check the result -->
+    <x:expect label="The colgroup span should be returned as the number of columns, even if it doesn't reflect table accurately">5</x:expect>
+  </x:scenario>
+
+  <x:scenario label="When matching a table with a tbody (no colgroup)">
+    <x:context mode="number.of.table.columns">
+      <table>
+	<thead>
+	  <tr>
+	    <th>First</th>
+	    <th>Second</th>
+	    <!-- Intentionally mismatching thead columns with tbody columns -->
+	  </tr>
+	</thead>
+	<tbody>
+	  <tr>
+	    <td>One</td>
+	    <td>Two</td>
+	    <td>Three</td>
+	  </tr>
+	  <tr>
+	    <td>Quatre</td>
+	    <td>Cinq</td>
+	    <td>Six</td>
+	  </tr>
+	</tbody>
+      </table>
+    </x:context>
+    <x:expect label="The correct number of columns should be inferred">3</x:expect>
+  </x:scenario>
+
+  <x:scenario label="When matching a table with a tbody (nonstandard colgroup should be ignored)">
+    <x:context mode="number.of.table.columns">
+      <table>
+	<colgroup>
+	  <col/>
+	</colgroup>
+	<thead>
+	  <tr>
+	    <th>First</th>
+	    <th>Second</th>
+	    <!-- Intentionally mismatching thead columns with tbody columns -->
+	  </tr>
+	</thead>
+	<tbody>
+	  <tr>
+	    <td>One</td>
+	    <td>Two</td>
+	    <td>Three</td>
+	  </tr>
+	  <tr>
+	    <td>Quatre</td>
+	    <td>Cinq</td>
+	    <td>Six</td>
+	  </tr>
+	</tbody>
+      </table>
+    </x:context>
+    <x:expect label="The correct number of columns should be inferred">3</x:expect>
+  </x:scenario>
+
+  <x:scenario label="When matching a table with a tbody (nonstandard colgroups should be ignored)">
+    <x:context mode="number.of.table.columns">
+      <table>
+	<colgroup span="2"/>
+	<colgroup span="4"/>
+	<thead>
+	  <tr>
+	    <th>First</th>
+	    <th>Second</th>
+	    <!-- Intentionally mismatching thead columns with tbody columns -->
+	  </tr>
+	</thead>
+	<tbody>
+	  <tr>
+	    <td>One</td>
+	    <td>Two</td>
+	    <td>Three</td>
+	  </tr>
+	  <tr>
+	    <td>Quatre</td>
+	    <td>Cinq</td>
+	    <td>Six</td>
+	  </tr>
+	</tbody>
+      </table>
+    </x:context>
+    <x:expect label="The correct number of columns should be inferred">3</x:expect>
+  </x:scenario>
+  
+  <x:scenario label="When matching a table without a tbody">
+    <x:context mode="number.of.table.columns">
+      <table>
+	<tr>
+	  <td>One</td>
+	  <td>Two</td>
+	  <td>Three</td>
+	  <td>Four</td>
+	</tr>
+	<tr>
+	  <td>Quatre</td>
+	  <td>Cinq</td>
+	  <td>Six</td>
+	  <td>Sept</td>
+	</tr>
+      </table>
+    </x:context>
+    <x:expect label="The correct number of columns should be inferred">4</x:expect>
+  </x:scenario>
+
+  <x:scenario label="When matching a table without a tbody (nonstandard colgroup should be ignored)">
+    <x:context mode="number.of.table.columns">
+      <table>
+	<colgroup>
+	  <col/>
+	</colgroup>
+	<tr>
+	  <td>One</td>
+	  <td>Two</td>
+	  <td>Three</td>
+	  <td>Four</td>
+	</tr>
+	<tr>
+	  <td>Quatre</td>
+	  <td>Cinq</td>
+	  <td>Six</td>
+	  <td>Sept</td>
+	</tr>
+      </table>
+    </x:context>
+    <x:expect label="The correct number of columns should be inferred">4</x:expect>
+  </x:scenario>
+
+  <x:scenario label="When matching a table without a tbody (nonstandard colgroups should be ignored)">
+    <x:context mode="number.of.table.columns">
+      <table>
+	<colgroup span="3"/>
+	<colgroup span="9"/>
+	<colgroup span="6"/>
+	<tr>
+	  <td>One</td>
+	  <td>Two</td>
+	  <td>Three</td>
+	  <td>Four</td>
+	</tr>
+	<tr>
+	  <td>Quatre</td>
+	  <td>Cinq</td>
+	  <td>Six</td>
+	  <td>Sept</td>
+	</tr>
+      </table>
+    </x:context>
+    <x:expect label="The correct number of columns should be inferred">4</x:expect>
+  </x:scenario>
+
 </x:description>

--- a/htmlbook-xsl/xspec/elements.xspec
+++ b/htmlbook-xsl/xspec/elements.xspec
@@ -1692,9 +1692,9 @@ sect5:1
       <table>
 	<caption>...</caption>
 	<tbody>...</tbody>
-	<tfoot class="footnotes">
+	<tfoot class="footnotes" >
 	  <tr>
-	    <td>
+	    <td colspan="2">
 	      <p data-type="footnote" id="tf1"><sup><a href="#tf1-marker">a</a></sup> Reddish</p>
 	      <p data-type="footnote" id="tf2"><sup><a href="#tf2-marker">b</a></sup> Bluish</p>
 	      <p data-type="footnote" id="tf3"><sup><a href="#tf3-marker">c</a></sup> Greenish</p>

--- a/htmlbook-xsl/xspec/elements.xspec
+++ b/htmlbook-xsl/xspec/elements.xspec
@@ -1692,7 +1692,7 @@ sect5:1
       <table>
 	<caption>...</caption>
 	<tbody>...</tbody>
-	<tfoot class="footnotes" >
+	<tfoot class="footnotes">
 	  <tr>
 	    <td colspan="2">
 	      <p data-type="footnote" id="tf1"><sup><a href="#tf1-marker">a</a></sup> Reddish</p>


### PR DESCRIPTION
Handling to calculate the number of columns in a table, and to add a colspan attribute to `<td>` in table footnotes `<tfoot>`.