### PR TITLE
Make sure subsections of frontmatter/backmatter are excluded from HTML and NCX TOC generation

### DIFF
--- a/htmlbook-xsl/ncx.xsl
+++ b/htmlbook-xsl/ncx.xsl
@@ -72,12 +72,20 @@
     </ncx>
   </xsl:template>
 
-  <!-- Default rule for TOC generation -->
+  <!-- Default rule for NCX TOC generation -->
   <xsl:template match="*" mode="ncx.toc.gen">
     <xsl:apply-templates select="*" mode="ncx.toc.gen"/>
   </xsl:template>
 
-  <xsl:template match="h:section[not(@data-type = 'dedication' or @data-type = 'titlepage' or @data-type = 'toc' or @data-type = 'colophon' or @data-type = 'copyright-page' or @data-type = 'halftitlepage')]|h:div[@data-type='part']" mode="ncx.toc.gen">
+  <!-- Exclude these frontmatter/backmatter sections from NCX TOC generation -->
+  <xsl:template match="h:section[@data-type = 'dedication' or
+		                 @data-type = 'titlepage' or
+				 @data-type = 'toc' or
+				 @data-type = 'colophon' or
+				 @data-type = 'copyright-page' or
+				 @data-type = 'halftitlepage']" mode="ncx.toc.gen"/>
+
+  <xsl:template match="h:section|h:div[@data-type='part']" mode="ncx.toc.gen">
     <xsl:choose>
       <!-- Don't generate NCX entries for sectNs of a level that exceeds specified NCX TOC section depth -->
       <xsl:when test="self::h:section[contains(@data-type, 'sect') and htmlbook:section-depth(.) != '' and htmlbook:section-depth(.) &gt; $ncx.toc.section.depth]"/>

--- a/htmlbook-xsl/tocgen.xsl
+++ b/htmlbook-xsl/tocgen.xsl
@@ -19,7 +19,15 @@
     </xsl:apply-templates>
   </xsl:template>
 
-  <xsl:template match="h:section[not(@data-type = 'dedication' or @data-type = 'titlepage' or @data-type = 'toc' or @data-type = 'colophon' or @data-type = 'copyright-page' or @data-type = 'halftitlepage')]|h:div[@data-type='part']" mode="tocgen">
+  <!-- Exclude these frontmatter/backmatter sections from TOC generation -->
+  <xsl:template match="h:section[@data-type = 'dedication' or 
+		                 @data-type = 'titlepage' or 
+				 @data-type = 'toc' or 
+				 @data-type = 'colophon' or 
+				 @data-type = 'copyright-page' or 
+				 @data-type = 'halftitlepage']" mode="tocgen"/>
+
+  <xsl:template match="h:section|h:div[@data-type='part']" mode="tocgen">
     <xsl:param name="toc.section.depth" select="$toc.section.depth"/>
     <xsl:choose>
       <!-- Don't output entry for section elements at a level that is greater than specified $toc.section.depth -->

--- a/htmlbook-xsl/xspec/ncx.xspec
+++ b/htmlbook-xsl/xspec/ncx.xspec
@@ -120,6 +120,41 @@ sect5:none
 	</x:scenario>
       </x:scenario>
     </x:scenario>
+	
+	
+	<x:scenario label="When a frontmatter/backmatter section is matched in ncx.toc.gen mode">
+		<x:context mode="ncx.toc.gen" select="(//h:body/h:section[@data-type='titlepage'])[1]" >
+			<body data-type="book">
+				<section data-type="titlepage">
+					<h1>You Don't Know JS</h1>
+				</section>
+				<section data-type="chapter">
+					<h1>Test Chapter</h1>
+					<p>It was the best of times!</p>
+				</section>
+			</body>
+		</x:context>
+		<x:expect label="It should not return a navPoint" select="()"/>
+	</x:scenario>
+	
+	<x:scenario label="When a subsection of a frontmatter/backmatter section is matched in ncx.toc.gen mode">
+		<x:context mode="ncx.toc.gen" select="(//h:body/h:section[@data-type='titlepage'])[1]" >
+			<body data-type="book">
+				<section data-type="titlepage">
+					<h1>You Don't Know JS</h1>
+					<section data-type="sect1">
+						<h1>Credits</h1>
+						<p>This section shouldn't show up in the TOC</p>
+					</section>
+				</section>
+				<section data-type="chapter">
+					<h1>Test Chapter</h1>
+					<p>It was the best of times!</p>
+				</section>
+			</body>
+		</x:context>
+		<x:expect label="It should not return a navPoint" select="()"/>
+	</x:scenario>
 
     <x:scenario label="When a non-book section/div is matched in ncx.toc.gen mode that does not have a book section/div child">
       <x:context mode="ncx.toc.gen">

--- a/htmlbook-xsl/xspec/tocgen.xspec
+++ b/htmlbook-xsl/xspec/tocgen.xspec
@@ -216,6 +216,58 @@
     <x:expect label="An entry 'li' *should not* be generated" select="()"/>
   </x:scenario>
   
+  <x:scenario label="When a frontmatter or backmatter section is matched in tocgen mode">
+    <x:context select="(//h:section[@data-type='colophon'])[1]" mode="tocgen">>
+      <x:param name="toc.section.depth" select="3"/>
+      <body data-type="book">
+        <section data-type="chapter">
+          <h1>First chapter</h1>
+          <section data-type="sect1">
+            <h1>First sect1</h1>
+            <p>A paragraph</p>
+          </section>
+        </section>
+        <section data-type="chapter">
+          <h1>Second chapter</h1>
+          <p>A paragraph</p>
+        </section>
+        <section data-type="colophon">
+          <h1>About the Author</h1>
+          <p>There shouldn't be an entry for this in the TOC</p>
+        </section>
+      </body>
+    </x:context>
+    <x:expect label="An entry 'li' *should not* be generated" select="()"/>
+  </x:scenario>
+  
+  <x:scenario label="When a subsection of a frontmatter or backmatter section is matched in tocgen mode">
+    <x:context select="(//h:section[@data-type='colophon']/h:section[@data-type='colophon'])[1]" mode="tocgen">>
+      <x:param name="toc.section.depth" select="3"/>
+      <body data-type="book">
+        <section data-type="chapter">
+          <h1>First chapter</h1>
+          <section data-type="sect1">
+            <h1>First sect1</h1>
+            <p>A paragraph</p>
+          </section>
+        </section>
+        <section data-type="chapter">
+          <h1>Second chapter</h1>
+          <p>A paragraph</p>
+        </section>
+        <section data-type="colophon">
+          <h1>About the Author</h1>
+          <p>Bio goes here</p>
+          <section data-type="sect1">
+            <h1>Acknowledgments</h1>
+            <p>There shouldn't be an entry for this in the TOC</p>
+          </section>
+        </section>
+      </body>
+    </x:context>
+    <x:expect label="An entry 'li' *should not* be generated" select="()"/>
+  </x:scenario>
+  
   <x:scenario label="When a nonsection is matched in tocgen mode">
     <x:context href="skeleton.html" select="(//h:p)[1]" mode="tocgen"/>
     <x:expect label="An entry 'li' *should not* be generated" select="()"/>

--- a/htmlbook-xsl/xspec/tocgen.xspec
+++ b/htmlbook-xsl/xspec/tocgen.xspec
@@ -241,7 +241,7 @@
   </x:scenario>
   
   <x:scenario label="When a subsection of a frontmatter or backmatter section is matched in tocgen mode">
-    <x:context select="(//h:section[@data-type='colophon']/h:section[@data-type='colophon'])[1]" mode="tocgen">>
+    <x:context select="(//h:section[@data-type='colophon'])[1]" mode="tocgen">>
       <x:param name="toc.section.depth" select="3"/>
       <body data-type="book">
         <section data-type="chapter">


### PR DESCRIPTION
Bug fix to ensure that if frontmatter and backmatter that are excluded from TOC generation by default (dedication, copyright page, titlepages, toc, and colophon) contain subsections, these subsections will also be excluded from TOC generation.