### PR TITLE
Backward-compatible tfoot generation for table footnotes

### DIFF
--- a/htmlbook-xsl/common.xsl
+++ b/htmlbook-xsl/common.xsl
@@ -693,11 +693,11 @@
       </xsl:when>
       <!-- Otherwise, if there's a tbody, use the number of columns in the first row of the last tbody -->
       <xsl:when test="h:tbody">
-	<xsl:value-of select="count(h:tbody[last()]/h:tr[1]/h:td)"/>
+	<xsl:value-of select="count(h:tbody[last()]/h:tr[1]/*[self::h:td or self::h:th])"/>
       </xsl:when>
       <!-- Otherwise, use the first row -->
       <xsl:otherwise>
-	<xsl:value-of select="count(h:tr[1]/h:td)"/>
+	<xsl:value-of select="count(h:tr[1]/*[self::h:td or self::h:th])"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>

--- a/htmlbook-xsl/elements.xsl
+++ b/htmlbook-xsl/elements.xsl
@@ -143,26 +143,62 @@
     </xsl:apply-templates>
   </xsl:template>
 
-  <!-- Custom handling for tables that have footnotes -->
-  <xsl:template match="h:table[descendant::h:span[@data-type='footnote']]">
+  <!-- BEGIN Custom handling for tables that have footnotes: -->
+  <!-- Three options -->
+  <!-- 1. Place footnotes in preexisting tfoot, if present. -->
+  <!-- 2. If no tfoot, but preexisting tbody, create tfoot before first tbody -->
+  <!-- 3. If no tfoot or tbody, create tfoot before first tr -->
+
+  <!-- OPTION 1 -->
+  <!-- There should only be one tfoot per table, but grab the last in case there's something odd in source -->
+  <xsl:template match="h:table[descendant::h:span[@data-type='footnote']]/h:tfoot[not(following-sibling::h:tfoot)]">
     <xsl:param name="process.footnotes" select="$process.footnotes"/>
     <xsl:variable name="number-of-table-columns">
-      <xsl:apply-templates select="." mode="number.of.table.columns"/>
+      <xsl:apply-templates select="parent::h:table" mode="number.of.table.columns"/>
     </xsl:variable>
     <xsl:copy>
-      <xsl:apply-templates select="@*|node()"/>
-      <!-- Put table footnotes in a tfoot -->
-      <tfoot class="footnotes">
-	<tr>
-	  <td colspan="{$number-of-table-columns}">
-	    <xsl:for-each select="descendant::h:span[@data-type='footnote']">
-	      <xsl:apply-templates select="." mode="generate.footnote"/>
-	    </xsl:for-each>
-	  </td>
-	</tr>
-      </tfoot>
+      <xsl:apply-templates select="@*"/>
+      <xsl:attribute name="class">
+	<xsl:value-of select="normalize-space(concat(@class, ' ', 'footnotes'))"/>
+      </xsl:attribute>
+      <xsl:apply-templates/>
+      <tr>
+	<td colspan="{$number-of-table-columns}">
+	  <xsl:for-each select="parent::h:table//h:span[@data-type='footnote']">
+	    <xsl:apply-templates select="." mode="generate.footnote"/>
+	  </xsl:for-each>
+	</td>
+      </tr>
     </xsl:copy>
   </xsl:template>
+
+  <!-- OPTIONS 2 and 3 -->
+  <!-- Find first tbody, but only in tables that don't have a tfoot (which are covered by OPTION 1) -->
+  <!-- and create footnotes tfoot before it -->
+  <!-- Find first tr, but only in tables that don't have a tfoot or a tbody, and create footnotes tfoot before it -->
+  <xsl:template match="h:table[descendant::h:span[@data-type='footnote'] 
+		               and not(h:tfoot)]/h:tbody[not(preceding-sibling::h:tbody)]|
+		       h:table[descendant::h:span[@data-type='footnote'] 
+		               and not(h:tfoot or h:tbody)]/h:tr[not(preceding-sibling::h:tr)]">
+    <xsl:param name="process.footnotes" select="$process.footnotes"/>
+    <xsl:variable name="number-of-table-columns">
+      <xsl:apply-templates select="parent::h:table" mode="number.of.table.columns"/>
+    </xsl:variable>
+    <tfoot class="footnotes">
+      <tr>
+	<td colspan="{$number-of-table-columns}">
+	  <xsl:for-each select="parent::h:table//h:span[@data-type='footnote']">
+	    <xsl:apply-templates select="." mode="generate.footnote"/>
+	  </xsl:for-each>
+	</td>
+      </tr>
+    </tfoot>
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- END Custom handling for tables that have footnotes: -->
 
   <xsl:template match="h:figure">
     <xsl:param name="html4.structural.elements" select="$html4.structural.elements"/>

--- a/htmlbook-xsl/elements.xsl
+++ b/htmlbook-xsl/elements.xsl
@@ -56,7 +56,7 @@
 		xmlns:svg="http://www.w3.org/2000/svg"
 		xmlns="http://www.w3.org/1999/xhtml"
 		extension-element-prefixes="exsl"
-		exclude-result-prefixes="exsl h">
+		exclude-result-prefixes="exsl h mml svg">
 
 <!-- Template for id decoration on elements that need it for TOC and/or index generation. 
      Should be at a lower import level than tocgen.xsl and indexgen.xsl, so that those

--- a/htmlbook-xsl/xspec/elements.xspec
+++ b/htmlbook-xsl/xspec/elements.xspec
@@ -1688,10 +1688,9 @@ sect5:1
       </table>
     </x:context>
 
-    <x:expect label="Footnotes should be added to a tfoot section at the end of table">
+    <x:expect label="Footnotes should be added to a tfoot section right before tbody">
       <table>
 	<caption>...</caption>
-	<tbody>...</tbody>
 	<tfoot class="footnotes">
 	  <tr>
 	    <td colspan="2">
@@ -1702,6 +1701,7 @@ sect5:1
 	    </td>
 	  </tr>
 	</tfoot>
+	<tbody>...</tbody>
       </table>
     </x:expect>
 
@@ -1730,6 +1730,140 @@ sect5:1
 	<sup><a data-type="noteref" href="#tf3">c</a></sup>
       </x:expect>
     </x:scenario>
+  </x:scenario>
+
+  <!-- Additional tfoot placement tests for different table source markup -->
+  <x:scenario label="When a table with footnotes is matched (no tbody)">
+    <x:context>
+      <table>
+	<caption>Four colors</caption>
+	<tr>
+	  <td>Vermillion<span id="tf1" data-type="footnote">Reddish</span></td>
+	  <td>Cerulean<span id="tf2" data-type="footnote">Bluish</span></td>
+	</tr>
+	<tr>
+	  <td>Chartreuse<span id="tf3" data-type="footnote">Greenish</span></td>
+	  <td>Fuschia<span id="tf4" data-type="footnote">Purplish</span></td>
+	</tr>
+	<tr>
+	  <td>Teal<a data-type="footnoteref" href="#tf3"/></td>
+	  <td>Eggplant<a data-type="footnoteref" href="#tf4"/></td>
+	</tr>
+      </table>
+    </x:context>
+
+    <x:expect label="Footnotes should be added to a tfoot section right before first tr">
+      <table>
+	<caption>...</caption>
+	<tfoot class="footnotes">
+	  <tr>
+	    <td colspan="2">
+	      <p data-type="footnote" id="tf1"><sup><a href="#tf1-marker">a</a></sup> Reddish</p>
+	      <p data-type="footnote" id="tf2"><sup><a href="#tf2-marker">b</a></sup> Bluish</p>
+	      <p data-type="footnote" id="tf3"><sup><a href="#tf3-marker">c</a></sup> Greenish</p>
+	      <p data-type="footnote" id="tf4"><sup><a href="#tf4-marker">d</a></sup> Purplish</p>
+	    </td>
+	  </tr>
+	</tfoot>
+	<tr>...</tr>
+	<tr>...</tr>
+	<tr>...</tr>
+      </table>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="When a table with footnotes is matched (no tbody; tfoot already present)">
+    <x:context>
+      <table>
+	<caption>Four colors</caption>
+	<tfoot>
+	  <tr><td>Thanks for reading this table!</td></tr>
+	</tfoot>
+	<tr>
+	  <td>Vermillion<span id="tf1" data-type="footnote">Reddish</span></td>
+	  <td>Cerulean<span id="tf2" data-type="footnote">Bluish</span></td>
+	</tr>
+	<tr>
+	  <td>Chartreuse<span id="tf3" data-type="footnote">Greenish</span></td>
+	  <td>Fuschia<span id="tf4" data-type="footnote">Purplish</span></td>
+	</tr>
+	<tr>
+	  <td>Teal<a data-type="footnoteref" href="#tf3"/></td>
+	  <td>Eggplant<a data-type="footnoteref" href="#tf4"/></td>
+	</tr>
+      </table>
+    </x:context>
+
+    <x:expect label="Footnotes should be added to the end of the existing tfoot section">
+      <table>
+	<caption>...</caption>
+	<tfoot class="footnotes">
+	  <tr><td>Thanks for reading this table!</td></tr>
+	  <tr>
+	    <td colspan="2">
+	      <p data-type="footnote" id="tf1"><sup><a href="#tf1-marker">a</a></sup> Reddish</p>
+	      <p data-type="footnote" id="tf2"><sup><a href="#tf2-marker">b</a></sup> Bluish</p>
+	      <p data-type="footnote" id="tf3"><sup><a href="#tf3-marker">c</a></sup> Greenish</p>
+	      <p data-type="footnote" id="tf4"><sup><a href="#tf4-marker">d</a></sup> Purplish</p>
+	    </td>
+	  </tr>
+	</tfoot>
+	<tr>...</tr>
+	<tr>...</tr>
+	<tr>...</tr>
+      </table>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="When a table with footnotes is matched (tbody present; tfoot already present)">
+    <x:context>
+      <table>
+	<caption>Four colors</caption>
+	<thead>
+	  <tr><th>Color</th><th>Color again</th></tr>
+	</thead>
+	<tfoot>
+	  <tr><td>Thanks for reading this table!</td></tr>
+	</tfoot>
+	<tbody>
+	  <tr>
+	    <td>Vermillion<span id="tf1" data-type="footnote">Reddish</span></td>
+	    <td>Cerulean<span id="tf2" data-type="footnote">Bluish</span></td>
+	  </tr>
+	  <tr>
+	    <td>Chartreuse<span id="tf3" data-type="footnote">Greenish</span></td>
+	    <td>Fuschia<span id="tf4" data-type="footnote">Purplish</span></td>
+	  </tr>
+	  <tr>
+	    <td>Teal<a data-type="footnoteref" href="#tf3"/></td>
+	    <td>Eggplant<a data-type="footnoteref" href="#tf4"/></td>
+	  </tr>
+	</tbody>
+      </table>
+    </x:context>
+
+    <x:expect label="Footnotes should be added to the end of the existing tfoot section">
+      <table>
+	<caption>...</caption>
+	<thead>...</thead>
+	<tfoot class="footnotes">
+	  <tr><td>Thanks for reading this table!</td></tr>
+	  <tr>
+	    <td colspan="2">
+	      <p data-type="footnote" id="tf1"><sup><a href="#tf1-marker">a</a></sup> Reddish</p>
+	      <p data-type="footnote" id="tf2"><sup><a href="#tf2-marker">b</a></sup> Bluish</p>
+	      <p data-type="footnote" id="tf3"><sup><a href="#tf3-marker">c</a></sup> Greenish</p>
+	      <p data-type="footnote" id="tf4"><sup><a href="#tf4-marker">d</a></sup> Purplish</p>
+	    </td>
+	  </tr>
+	</tfoot>
+	<tbody>
+	  <tr>...</tr>
+	  <tr>...</tr>
+	  <tr>...</tr>
+	</tbody>
+      </table>
+    </x:expect>
   </x:scenario>
 
   <x:scenario label="When a section is matched that has both footnotes and table footnotes">


### PR DESCRIPTION
Adjusted generation of `<tfoot>` elements for table footnotes so that `<tfoot>`s are generated before `<tbody>` or (if no `<tbody>`) the first `<tr>`, rather than at the end of the `<table>`, so that output content model is compatible with both XHTML 1.1 and XHTML5.

Also made `number.of.table.column` handling more robust, accounting for `<th>` as well as `<td>`.