### PR TITLE
More backward-compatibility adjustments for table footnote generation

### DIFF
--- a/htmlbook-xsl/elements.xsl
+++ b/htmlbook-xsl/elements.xsl
@@ -144,57 +144,35 @@
   </xsl:template>
 
   <!-- BEGIN Custom handling for tables that have footnotes: -->
-  <!-- Three options -->
-  <!-- 1. Place footnotes in preexisting tfoot, if present. -->
-  <!-- 2. If no tfoot, but preexisting tbody, create tfoot before first tbody -->
-  <!-- 3. If no tfoot or tbody, create tfoot before first tr -->
 
-  <!-- OPTION 1 -->
-  <!-- There should only be one tfoot per table, but grab the last in case there's something odd in source -->
-  <xsl:template match="h:table[descendant::h:span[@data-type='footnote']]/h:tfoot[not(following-sibling::h:tfoot)]">
+  <xsl:template match="h:table[descendant::h:span[@data-type='footnote']]">
     <xsl:param name="process.footnotes" select="$process.footnotes"/>
     <xsl:variable name="number-of-table-columns">
-      <xsl:apply-templates select="parent::h:table" mode="number.of.table.columns"/>
+      <xsl:apply-templates select="." mode="number.of.table.columns"/>
     </xsl:variable>
-    <xsl:copy>
-      <xsl:apply-templates select="@*"/>
-      <xsl:attribute name="class">
-	<xsl:value-of select="normalize-space(concat(@class, ' ', 'footnotes'))"/>
-      </xsl:attribute>
-      <xsl:apply-templates/>
-      <tr>
-	<td colspan="{$number-of-table-columns}">
-	  <xsl:for-each select="parent::h:table//h:span[@data-type='footnote']">
-	    <xsl:apply-templates select="." mode="generate.footnote"/>
-	  </xsl:for-each>
-	</td>
-      </tr>
-    </xsl:copy>
-  </xsl:template>
-
-  <!-- OPTIONS 2 and 3 -->
-  <!-- Find first tbody, but only in tables that don't have a tfoot (which are covered by OPTION 1) -->
-  <!-- and create footnotes tfoot before it -->
-  <!-- Find first tr, but only in tables that don't have a tfoot or a tbody, and create footnotes tfoot before it -->
-  <xsl:template match="h:table[descendant::h:span[@data-type='footnote'] 
-		               and not(h:tfoot)]/h:tbody[not(preceding-sibling::h:tbody)]|
-		       h:table[descendant::h:span[@data-type='footnote'] 
-		               and not(h:tfoot or h:tbody)]/h:tr[not(preceding-sibling::h:tr)]">
-    <xsl:param name="process.footnotes" select="$process.footnotes"/>
-    <xsl:variable name="number-of-table-columns">
-      <xsl:apply-templates select="parent::h:table" mode="number.of.table.columns"/>
-    </xsl:variable>
-    <tfoot class="footnotes">
-      <tr>
-	<td colspan="{$number-of-table-columns}">
-	  <xsl:for-each select="parent::h:table//h:span[@data-type='footnote']">
-	    <xsl:apply-templates select="." mode="generate.footnote"/>
-	  </xsl:for-each>
-	</td>
-      </tr>
-    </tfoot>
     <xsl:copy>
       <xsl:apply-templates select="@*|node()"/>
+      <xsl:variable name="footnote-row">
+	<tr class="footnotes">
+	  <td colspan="{$number-of-table-columns}">
+	    <xsl:for-each select="descendant::h:span[@data-type='footnote']">
+	      <xsl:apply-templates select="." mode="generate.footnote"/>
+	    </xsl:for-each>
+	  </td>
+	</tr>
+      </xsl:variable>
+      <xsl:choose>
+	<!-- Put footnote row in tbody, when other tbody elements exist -->
+	<xsl:when test="h:tbody">
+	  <tbody>
+	    <xsl:copy-of select="$footnote-row"/>
+	  </tbody>
+	</xsl:when>
+	<xsl:otherwise>
+	  <!-- Otherwise, put footnote row in loose -->
+	  <xsl:copy-of select="$footnote-row"/>
+	</xsl:otherwise>
+      </xsl:choose>
     </xsl:copy>
   </xsl:template>
 

--- a/htmlbook-xsl/xspec/elements.xspec
+++ b/htmlbook-xsl/xspec/elements.xspec
@@ -1688,11 +1688,12 @@ sect5:1
       </table>
     </x:context>
 
-    <x:expect label="Footnotes should be added to a tfoot section right before tbody">
+    <x:expect label="Footnotes should be added to a tbody section at end of table">
       <table>
 	<caption>...</caption>
-	<tfoot class="footnotes">
-	  <tr>
+	<tbody>...</tbody>
+	<tbody>
+	  <tr class="footnotes">
 	    <td colspan="2">
 	      <p data-type="footnote" id="tf1"><sup><a href="#tf1-marker">a</a></sup> Reddish</p>
 	      <p data-type="footnote" id="tf2"><sup><a href="#tf2-marker">b</a></sup> Bluish</p>
@@ -1700,8 +1701,7 @@ sect5:1
 	      <p data-type="footnote" id="tf4"><sup><a href="#tf4-marker">d</a></sup> Purplish</p>
 	    </td>
 	  </tr>
-	</tfoot>
-	<tbody>...</tbody>
+	</tbody>
       </table>
     </x:expect>
 
@@ -1732,7 +1732,7 @@ sect5:1
     </x:scenario>
   </x:scenario>
 
-  <!-- Additional tfoot placement tests for different table source markup -->
+  <!-- Additional table footnote placement tests for different table source markup -->
   <x:scenario label="When a table with footnotes is matched (no tbody)">
     <x:context>
       <table>
@@ -1752,116 +1752,20 @@ sect5:1
       </table>
     </x:context>
 
-    <x:expect label="Footnotes should be added to a tfoot section right before first tr">
+    <x:expect label="Footnotes should be added to a tr at the end of the table">
       <table>
 	<caption>...</caption>
-	<tfoot class="footnotes">
-	  <tr>
-	    <td colspan="2">
-	      <p data-type="footnote" id="tf1"><sup><a href="#tf1-marker">a</a></sup> Reddish</p>
-	      <p data-type="footnote" id="tf2"><sup><a href="#tf2-marker">b</a></sup> Bluish</p>
-	      <p data-type="footnote" id="tf3"><sup><a href="#tf3-marker">c</a></sup> Greenish</p>
-	      <p data-type="footnote" id="tf4"><sup><a href="#tf4-marker">d</a></sup> Purplish</p>
-	    </td>
-	  </tr>
-	</tfoot>
 	<tr>...</tr>
 	<tr>...</tr>
 	<tr>...</tr>
-      </table>
-    </x:expect>
-  </x:scenario>
-
-  <x:scenario label="When a table with footnotes is matched (no tbody; tfoot already present)">
-    <x:context>
-      <table>
-	<caption>Four colors</caption>
-	<tfoot>
-	  <tr><td>Thanks for reading this table!</td></tr>
-	</tfoot>
-	<tr>
-	  <td>Vermillion<span id="tf1" data-type="footnote">Reddish</span></td>
-	  <td>Cerulean<span id="tf2" data-type="footnote">Bluish</span></td>
+	<tr class="footnotes">
+	  <td colspan="2">
+	    <p data-type="footnote" id="tf1"><sup><a href="#tf1-marker">a</a></sup> Reddish</p>
+	    <p data-type="footnote" id="tf2"><sup><a href="#tf2-marker">b</a></sup> Bluish</p>
+	    <p data-type="footnote" id="tf3"><sup><a href="#tf3-marker">c</a></sup> Greenish</p>
+	    <p data-type="footnote" id="tf4"><sup><a href="#tf4-marker">d</a></sup> Purplish</p>
+	  </td>
 	</tr>
-	<tr>
-	  <td>Chartreuse<span id="tf3" data-type="footnote">Greenish</span></td>
-	  <td>Fuschia<span id="tf4" data-type="footnote">Purplish</span></td>
-	</tr>
-	<tr>
-	  <td>Teal<a data-type="footnoteref" href="#tf3"/></td>
-	  <td>Eggplant<a data-type="footnoteref" href="#tf4"/></td>
-	</tr>
-      </table>
-    </x:context>
-
-    <x:expect label="Footnotes should be added to the end of the existing tfoot section">
-      <table>
-	<caption>...</caption>
-	<tfoot class="footnotes">
-	  <tr><td>Thanks for reading this table!</td></tr>
-	  <tr>
-	    <td colspan="2">
-	      <p data-type="footnote" id="tf1"><sup><a href="#tf1-marker">a</a></sup> Reddish</p>
-	      <p data-type="footnote" id="tf2"><sup><a href="#tf2-marker">b</a></sup> Bluish</p>
-	      <p data-type="footnote" id="tf3"><sup><a href="#tf3-marker">c</a></sup> Greenish</p>
-	      <p data-type="footnote" id="tf4"><sup><a href="#tf4-marker">d</a></sup> Purplish</p>
-	    </td>
-	  </tr>
-	</tfoot>
-	<tr>...</tr>
-	<tr>...</tr>
-	<tr>...</tr>
-      </table>
-    </x:expect>
-  </x:scenario>
-
-  <x:scenario label="When a table with footnotes is matched (tbody present; tfoot already present)">
-    <x:context>
-      <table>
-	<caption>Four colors</caption>
-	<thead>
-	  <tr><th>Color</th><th>Color again</th></tr>
-	</thead>
-	<tfoot>
-	  <tr><td>Thanks for reading this table!</td></tr>
-	</tfoot>
-	<tbody>
-	  <tr>
-	    <td>Vermillion<span id="tf1" data-type="footnote">Reddish</span></td>
-	    <td>Cerulean<span id="tf2" data-type="footnote">Bluish</span></td>
-	  </tr>
-	  <tr>
-	    <td>Chartreuse<span id="tf3" data-type="footnote">Greenish</span></td>
-	    <td>Fuschia<span id="tf4" data-type="footnote">Purplish</span></td>
-	  </tr>
-	  <tr>
-	    <td>Teal<a data-type="footnoteref" href="#tf3"/></td>
-	    <td>Eggplant<a data-type="footnoteref" href="#tf4"/></td>
-	  </tr>
-	</tbody>
-      </table>
-    </x:context>
-
-    <x:expect label="Footnotes should be added to the end of the existing tfoot section">
-      <table>
-	<caption>...</caption>
-	<thead>...</thead>
-	<tfoot class="footnotes">
-	  <tr><td>Thanks for reading this table!</td></tr>
-	  <tr>
-	    <td colspan="2">
-	      <p data-type="footnote" id="tf1"><sup><a href="#tf1-marker">a</a></sup> Reddish</p>
-	      <p data-type="footnote" id="tf2"><sup><a href="#tf2-marker">b</a></sup> Bluish</p>
-	      <p data-type="footnote" id="tf3"><sup><a href="#tf3-marker">c</a></sup> Greenish</p>
-	      <p data-type="footnote" id="tf4"><sup><a href="#tf4-marker">d</a></sup> Purplish</p>
-	    </td>
-	  </tr>
-	</tfoot>
-	<tbody>
-	  <tr>...</tr>
-	  <tr>...</tr>
-	  <tr>...</tr>
-	</tbody>
       </table>
     </x:expect>
   </x:scenario>
@@ -1892,7 +1796,7 @@ sect5:1
       <x:context>
 	<x:param name="process.footnotes" select="0"/>
       </x:context>
-      <x:expect label="There should be 4 footnotes at end of table" test="count(//h:table//h:tfoot//*[@data-type='footnote']) = 4"/>
+      <x:expect label="There should be 4 footnotes at end of table" test="count(//h:table//h:tr[@class = 'footnotes']//*[@data-type='footnote']) = 4"/>
       <x:expect label="There should be no footnotes at end of section" test="count(//h:section/h:aside//*[@data-type='footnote']) = 0"/>
     </x:scenario>
 
@@ -1900,7 +1804,7 @@ sect5:1
       <x:context>
 	<x:param name="process.footnotes" select="1"/>
       </x:context>
-      <x:expect label="There should be 4 footnotes at end of table" test="count(//h:table//h:tfoot//*[@data-type='footnote']) = 4"/>
+      <x:expect label="There should be 4 footnotes at end of table" test="count(//h:table//h:tr[@class = 'footnotes']//*[@data-type='footnote']) = 4"/>
       <x:expect label="There should be 2 footnotes at end of section" test="count(//h:section/h:aside//*[@data-type='footnote']) = 2"/>
       <x:expect label="Footnotes at end of section should be numbered in sequence" test="every $footnote in (//h:p[@data-type='footnote'][ancestor::h:aside]) satisfies $footnote[count(preceding-sibling::h:p[@data-type='footnote']) + 1 = h:sup/h:a]"/>
     </x:scenario>


### PR DESCRIPTION
Some legacy ereading engines don't properly float `<tfoot>` content to the bottom of a table, so switching to use `<tbody>` at end of table (or loose `<tr>` if table contains no `<tbody>`) for widest compatibility (even though it's a bit of a shame semantically)