### PR TITLE
Added inline.markup.in.toc param

### DIFF
--- a/htmlbook-xsl/epub.xsl
+++ b/htmlbook-xsl/epub.xsl
@@ -192,6 +192,9 @@
   <!-- Don't turn this parameter on if you're not generating a root chunk -->
   <xsl:param name="ncx.include.root.chunk" select="$generate.root.chunk"/>
 
+  <!-- Param to specify whether or not to include inline markup tagging (e.g., "em", "code") in generated XHTML TOC (EPUB Navigation Document) -->
+  <xsl:param name="inline.markup.in.toc" select="0"/>
+
   <!-- Param to specify whether or not to include the Navigation Document (XHTML5 TOC) in the spine -->
   <xsl:param name="nav.in.spine" select="0"/>
 

--- a/htmlbook-xsl/param.xsl
+++ b/htmlbook-xsl/param.xsl
@@ -117,6 +117,9 @@ sect5:none
     -->
   <xsl:param name="toc.section.depth" select="2"/>
 
+  <!-- Param to specify whether or not to include inline markup tagging (e.g., "em", "code") in generated XHTML TOC (EPUB Navigation Document) -->
+  <xsl:param name="inline.markup.in.toc" select="1"/>
+
   <!-- XREF-specific params -->
   <xsl:param name="autogenerate-xrefs" select="1"/>
 

--- a/htmlbook-xsl/param.xsl
+++ b/htmlbook-xsl/param.xsl
@@ -117,7 +117,7 @@ sect5:none
     -->
   <xsl:param name="toc.section.depth" select="2"/>
 
-  <!-- Param to specify whether or not to include inline markup tagging (e.g., "em", "code") in generated XHTML TOC (EPUB Navigation Document) -->
+  <!-- Param to specify whether or not to include inline markup tagging (e.g., "em", "code") in generated XHTML TOC -->
   <xsl:param name="inline.markup.in.toc" select="1"/>
 
   <!-- XREF-specific params -->

--- a/htmlbook-xsl/tocgen.xsl
+++ b/htmlbook-xsl/tocgen.xsl
@@ -29,6 +29,7 @@
 
   <xsl:template match="h:section|h:div[@data-type='part']" mode="tocgen">
     <xsl:param name="toc.section.depth" select="$toc.section.depth"/>
+    <xsl:param name="inline.markup.in.toc" select="$inline.markup.in.toc"/>
     <xsl:choose>
       <!-- Don't output entry for section elements at a level that is greater than specified $toc.section.depth -->
       <xsl:when test="self::h:section[contains(@data-type, 'sect') and htmlbook:section-depth(.) != '' and htmlbook:section-depth(.) &gt; $toc.section.depth]"/>
@@ -55,7 +56,19 @@
 		<xsl:value-of select="$label.and.title.separator"/>
 	      </xsl:if>
 	    </xsl:if>
-	    <xsl:apply-templates select="." mode="title.markup"/>
+	    <xsl:choose>
+	      <xsl:when test="$inline.markup.in.toc = 1">
+		<!-- Include inline elements in TOC entry -->
+		<xsl:apply-templates select="." mode="title.markup"/>
+	      </xsl:when>
+	      <xsl:otherwise>
+		<!-- Strip inline tagging from TOC entry: raw text only -->
+		<xsl:variable name="title.markup">
+		  <xsl:apply-templates select="." mode="title.markup"/>
+		</xsl:variable>
+		<xsl:value-of select="$title.markup"/>
+	      </xsl:otherwise>
+	    </xsl:choose>		
 	  </a>
 	  <!-- Make sure there are descendants that conform to $toc.section.depth restrictions before generating nested TOC <ol> -->
 	  <xsl:if test="descendant::h:section[not(contains(@data-type, 'sect')) or htmlbook:section-depth(.) &lt;= $toc.section.depth]|descendant::h:div[@data-type='part']">

--- a/htmlbook-xsl/xspec/tocgen.xspec
+++ b/htmlbook-xsl/xspec/tocgen.xspec
@@ -273,6 +273,42 @@
     <x:expect label="An entry 'li' *should not* be generated" select="()"/>
   </x:scenario>
 
+  <!-- Inline markup in TOC tests -->
+  <x:scenario label="When a section with inline markup in its heading is matched in tocgen mode">
+    <x:context select="(//h:section[@data-type='sect1'])[1]" mode="tocgen">>
+      <x:param name="toc.section.depth" select="3"/>
+      <body data-type="book">
+        <section data-type="chapter">
+          <h1>First chapter</h1>
+          <section data-type="sect1">
+            <h1>First sect1 with <em>inline tagging</em></h1>
+            <p>A paragraph</p>
+          </section>
+        </section>
+      </body>
+    </x:context>
+    
+    <x:scenario label="And inline.markup.in.toc disabled">
+      <x:context>
+	<x:param name="inline.markup.in.toc" select="0"/>
+      </x:context>
+
+      <x:expect label="An entry 'li' should be generated *without* inline markup">
+	<li data-type="sect1"><a href="...">First sect1 with inline tagging</a></li>
+      </x:expect>
+    </x:scenario>
+    
+    <x:scenario label="And inline.markup.in.toc enabled">
+      <x:context>
+	<x:param name="inline.markup.in.toc" select="1"/>
+      </x:context>
+
+      <x:expect label="An entry 'li' should be generated *with* inline markup">
+	<li data-type="sect1"><a href="...">First sect1 with <em>inline tagging</em></a></li>
+      </x:expect>
+    </x:scenario>
+  </x:scenario>
+
   <x:scenario label="When toc-title is called for English-language content (default)">
     <x:call template="toc-title"/>
     <x:expect label="it should return the proper TOC title">Table of Contents</x:expect>


### PR DESCRIPTION
Added `inline.markup.in.toc` param to allow enabling/disabling inclusion of inline markup tagging (e.g., `em`, `code`) in autogenerated XHTML TOCs.

Set `inline.markup.in.toc` to `0` to drop inline markup tagging from TOC entries, and set `inline.markup.in.toc` to `1` to preserve inline tagging from section headings in TOC entries.

Default behavior is to preserve inline markup tagging in TOC in `param.xsl`, but to disable it in `epub.xsl` (to drop inline markup tagging from EPUB Navigation document, which, while valid EPUB 3, might result in rendering issues in some ereaders).