### PR TITLE
Added data-footnote-marker attribute to footnotes

### DIFF
--- a/htmlbook-xsl/elements.xsl
+++ b/htmlbook-xsl/elements.xsl
@@ -315,7 +315,13 @@
       </xsl:when>
       <xsl:otherwise>
 	<xsl:copy>
-	  <xsl:apply-templates select="@*|node()"/>
+	  <xsl:apply-templates select="@*"/>
+	  <xsl:attribute name="data-footnote-marker">
+	    <xsl:apply-templates select="." mode="footnote.number">
+	      <xsl:with-param name="footnote.reset.numbering.at.chapter.level" select="$footnote.reset.numbering.at.chapter.level"/>
+	    </xsl:apply-templates>
+	  </xsl:attribute>
+	  <xsl:apply-templates/>
 	</xsl:copy>
       </xsl:otherwise>
     </xsl:choose>

--- a/htmlbook-xsl/xspec/elements.xspec
+++ b/htmlbook-xsl/xspec/elements.xspec
@@ -1445,7 +1445,7 @@ sect5:1
 	<x:param name="process.footnotes" select="0"/>
       </x:context>
       <x:expect label="Footnote should be copied to output as is">
-	<span data-type="footnote" id="fn_id_yo">And this is the footnote</span>
+	<span data-type="footnote" id="fn_id_yo" data-footnote-marker="...">And this is the footnote</span>
       </x:expect>
     </x:scenario>
 
@@ -1495,6 +1495,26 @@ sect5:1
 	<p>Here's the second footnote<span data-type="footnote">Footnote #2 in the Appendix</span></p>
       </section>
     </x:context>
+
+    <x:scenario label="With process footnotes disabled and footnote.reset.numbering.at.chapter.level disabled">
+      <x:context select="(/h:section[@id='second_ch']//h:span[@data-type='footnote'])[2]">
+	<x:param name="process.footnotes" select="0"/>
+	<x:param name="footnote.reset.numbering.at.chapter.level" select="0"/>
+      </x:context>
+      <x:expect label="Footnote should be postprocessing with the proper data-footnote-marker attribute">
+	<span data-footnote-marker="4" data-type="footnote">Footnote #2 in Chapter #2</span>
+      </x:expect>
+    </x:scenario>
+
+    <x:scenario label="With process footnotes disabled and footnote.reset.numbering.at.chapter.level enabled">
+      <x:context select="(/h:section[@id='second_ch']//h:span[@data-type='footnote'])[2]">
+	<x:param name="process.footnotes" select="0"/>
+	<x:param name="footnote.reset.numbering.at.chapter.level" select="1"/>
+      </x:context>
+      <x:expect label="Footnote should be postprocessing with the proper data-footnote-marker attribute">
+	<span data-footnote-marker="2" data-type="footnote">Footnote #2 in Chapter #2</span>
+      </x:expect>
+    </x:scenario>
 
     <x:scenario label="With process footnotes enabled and footnote.reset.numbering.at.chapter.level disabled">
       <x:context select="(/h:section[@id='second_ch']//h:span[@data-type='footnote'])[2]">


### PR DESCRIPTION
Added data-footnote-marker attribute to `<span data-type="footnote">` when `process.footnotes` parameter is disabled (i.e., in cases where footnote `<span>`s are postprocessed in place, rather than moved to the end of a section). Results look like this:

````html
<span data-footnote-marker="2" data-type="footnote">Footnote #2 in Chapter #2</span>
````

The data-footnote-marker contains the value of the `footnote.number` template, and can be used by CSS for numbering in cases where it might not be feasible to use `counter()`.