### PR TITLE
New process.footnote.callouts.only parameter

### DIFF
--- a/htmlbook-xsl/elements.xsl
+++ b/htmlbook-xsl/elements.xsl
@@ -307,24 +307,31 @@
   <xsl:template match="h:span[@data-type='footnote']">
     <xsl:param name="footnote.reset.numbering.at.chapter.level" select="$footnote.reset.numbering.at.chapter.level"/>
     <xsl:param name="process.footnotes" select="$process.footnotes"/>
-    <xsl:choose>
-      <xsl:when test="($process.footnotes = 1) or ancestor::h:table">
-	<xsl:apply-templates select="." mode="footnote.marker">
-	  <xsl:with-param name="footnote.reset.numbering.at.chapter.level" select="$footnote.reset.numbering.at.chapter.level"/>
-	</xsl:apply-templates>
-      </xsl:when>
-      <xsl:otherwise>
-	<xsl:copy>
-	  <xsl:apply-templates select="@*"/>
-	  <xsl:attribute name="data-footnote-marker">
-	    <xsl:apply-templates select="." mode="footnote.number">
-	      <xsl:with-param name="footnote.reset.numbering.at.chapter.level" select="$footnote.reset.numbering.at.chapter.level"/>
-	    </xsl:apply-templates>
+    <xsl:param name="process.footnote.callouts.only" select="$process.footnote.callouts.only"/>
+    <xsl:if test="($process.footnotes = 1) or ($process.footnote.callouts.only = 1) or ancestor::h:table">
+      <!-- Generate marker if we're processing footnotes completely, processing just footnote callouts, or working on a table footnote -->
+      <xsl:apply-templates select="." mode="footnote.marker">
+	<xsl:with-param name="footnote.reset.numbering.at.chapter.level" select="$footnote.reset.numbering.at.chapter.level"/>
+      </xsl:apply-templates>
+    </xsl:if>
+    <!-- Copy footnote content in place if we're not processing footnotes completely and not working on a table footnote -->
+    <xsl:if test="($process.footnotes != 1) and not(ancestor::h:table)">
+      <xsl:copy>
+	<xsl:apply-templates select="@*"/>
+	<!-- Need to ensure there are ids if process.footnote.callouts.only is enabled -->
+	<xsl:if test="$process.footnote.callouts.only = 1">
+	  <xsl:attribute name="id">
+	    <xsl:call-template name="object.id"/>
 	  </xsl:attribute>
-	  <xsl:apply-templates/>
-	</xsl:copy>
-      </xsl:otherwise>
-    </xsl:choose>
+	</xsl:if>
+	<xsl:attribute name="data-footnote-marker">
+	  <xsl:apply-templates select="." mode="footnote.number">
+	    <xsl:with-param name="footnote.reset.numbering.at.chapter.level" select="$footnote.reset.numbering.at.chapter.level"/>
+	  </xsl:apply-templates>
+	</xsl:attribute>
+	<xsl:apply-templates/>
+      </xsl:copy>
+    </xsl:if>
   </xsl:template>
 
   <xsl:template match="h:span[@data-type='footnote']" mode="footnote.marker" name="footnote-marker">

--- a/htmlbook-xsl/param.xsl
+++ b/htmlbook-xsl/param.xsl
@@ -174,8 +174,11 @@ toc:lower-roman
 
   <!-- Footnote-specific params -->
 
-  <!-- Process footnotes into separate marker/hyperlink and footnote content -->
+  <!-- Process footnotes into separate marker/hyperlink and footnote content, and move to end of sections -->
   <xsl:param name="process.footnotes" select="0"/>
+
+  <!-- Generate hardcoded superscripted markers for footnotes, but don't move footnote contente to end of sections -->
+  <xsl:param name="process.footnote.callouts.only" select="0"/>
 
   <!-- Reset footnote numbering at chapter level elements (children of part or body) -->
   <xsl:param name="footnote.reset.numbering.at.chapter.level" select="1"/>

--- a/htmlbook-xsl/xspec/elements.xspec
+++ b/htmlbook-xsl/xspec/elements.xspec
@@ -1440,18 +1440,30 @@ sect5:1
       <p>This is the text<span id="fn_id_yo" data-type="footnote">And this is the footnote</span></p>
     </x:context>
     
-    <x:scenario label="With process.footnotes disabled">
+    <x:scenario label="With process.footnotes disabled and process.footnote.callouts.only disabled">
       <x:context>
 	<x:param name="process.footnotes" select="0"/>
+	<x:param name="process.footnote.callouts.only" select="0"/>
       </x:context>
       <x:expect label="Footnote should be copied to output as is">
 	<span data-type="footnote" id="fn_id_yo" data-footnote-marker="...">And this is the footnote</span>
       </x:expect>
     </x:scenario>
 
+    <x:scenario label="With process.footnotes disabled and process.footnote.callouts.only enabled">
+      <x:context>
+	<x:param name="process.footnotes" select="0"/>
+	<x:param name="process.footnote.callouts.only" select="1"/>
+      </x:context>
+      <x:expect label="Footnote callout should be generated and followed by footnote copied to output as is">
+	<sup><a data-type="noteref" id="fn_id_yo-marker" href="#fn_id_yo">1</a></sup><span data-type="footnote" id="fn_id_yo" data-footnote-marker="...">And this is the footnote</span>
+      </x:expect>
+    </x:scenario>
+
     <x:scenario label="With process.footnotes enabled">
       <x:context>
 	<x:param name="process.footnotes" select="1"/>
+	<x:param name="process.footnote.callouts.only" select="0"/>
       </x:context>
       <x:expect label="Footnote should be processed to a noteref">
 	<sup>
@@ -1499,9 +1511,10 @@ sect5:1
     <x:scenario label="With process footnotes disabled and footnote.reset.numbering.at.chapter.level disabled">
       <x:context select="(/h:section[@id='second_ch']//h:span[@data-type='footnote'])[2]">
 	<x:param name="process.footnotes" select="0"/>
+	<x:param name="process.footnote.callouts.only" select="0"/>
 	<x:param name="footnote.reset.numbering.at.chapter.level" select="0"/>
       </x:context>
-      <x:expect label="Footnote should be postprocessing with the proper data-footnote-marker attribute">
+      <x:expect label="Footnote should be postprocessed with the proper data-footnote-marker attribute">
 	<span data-footnote-marker="4" data-type="footnote">Footnote #2 in Chapter #2</span>
       </x:expect>
     </x:scenario>
@@ -1509,16 +1522,42 @@ sect5:1
     <x:scenario label="With process footnotes disabled and footnote.reset.numbering.at.chapter.level enabled">
       <x:context select="(/h:section[@id='second_ch']//h:span[@data-type='footnote'])[2]">
 	<x:param name="process.footnotes" select="0"/>
+	<x:param name="process.footnote.callouts.only" select="0"/>
 	<x:param name="footnote.reset.numbering.at.chapter.level" select="1"/>
       </x:context>
-      <x:expect label="Footnote should be postprocessing with the proper data-footnote-marker attribute">
+      <x:expect label="Footnote should be postprocessed with the proper data-footnote-marker attribute">
 	<span data-footnote-marker="2" data-type="footnote">Footnote #2 in Chapter #2</span>
       </x:expect>
+    </x:scenario>
+
+    <x:scenario label="With process footnotes disabled, process.footnote.callouts.only enabled, and footnote.reset.numbering.at.chapter.level disabled">
+      <x:context select="(/h:section[@id='second_ch']//h:span[@data-type='footnote'])[2]">
+	<x:param name="process.footnotes" select="0"/>
+	<x:param name="process.footnote.callouts.only" select="1"/>
+	<x:param name="footnote.reset.numbering.at.chapter.level" select="0"/>
+      </x:context>
+      <x:expect label="Footnote should be postprocessed with the proper data-footnote-marker attribute">
+	<sup><a id="..." data-type="noteref" href="...">4</a></sup><span id="..." data-footnote-marker="4" data-type="footnote">Footnote #2 in Chapter #2</span>
+      </x:expect>
+      <x:expect label="Footnote call href should match footnote id" test="substring-after(//h:a[@data-type='noteref'][1]/@href, '#') = /h:span[@data-type='footnote'][1]/@id"/>
+    </x:scenario>
+
+    <x:scenario label="With process footnotes disabled, process.footnote.callouts.only enabled, and footnote.reset.numbering.at.chapter.level enabled">
+      <x:context select="(/h:section[@id='second_ch']//h:span[@data-type='footnote'])[2]">
+	<x:param name="process.footnotes" select="0"/>
+	<x:param name="process.footnote.callouts.only" select="1"/>
+	<x:param name="footnote.reset.numbering.at.chapter.level" select="1"/>
+      </x:context>
+      <x:expect label="Footnote should be postprocessed with the proper data-footnote-marker attribute">
+	<sup><a id="..." data-type="noteref" href="...">2</a></sup><span id="..." data-footnote-marker="2" data-type="footnote">Footnote #2 in Chapter #2</span>
+      </x:expect>
+      <x:expect label="Footnote call href should match footnote id" test="substring-after(//h:a[@data-type='noteref'][1]/@href, '#') = /h:span[@data-type='footnote'][1]/@id"/>
     </x:scenario>
 
     <x:scenario label="With process footnotes enabled and footnote.reset.numbering.at.chapter.level disabled">
       <x:context select="(/h:section[@id='second_ch']//h:span[@data-type='footnote'])[2]">
 	<x:param name="process.footnotes" select="1"/>
+	<x:param name="process.footnote.callouts.only" select="0"/>
 	<x:param name="footnote.reset.numbering.at.chapter.level" select="0"/>
       </x:context>
       <x:expect label="Footnote should be processed to a noteref with proper number">
@@ -1531,6 +1570,7 @@ sect5:1
     <x:scenario label="With process footnotes enabled and footnote.reset.numbering.at.chapter.level enabled">
       <x:context select="(/h:section[@id='second_ch']//h:span[@data-type='footnote'])[2]">
 	<x:param name="process.footnotes" select="1"/>
+	<x:param name="process.footnote.callouts.only" select="0"/>
 	<x:param name="footnote.reset.numbering.at.chapter.level" select="1"/>
       </x:context>
       <x:expect label="Footnote should be processed to a noteref with proper number">
@@ -1543,6 +1583,7 @@ sect5:1
     <x:scenario label="With process footnotes enabled and footnote.reset.numbering.at.chapter.level disabled (end-of-section footnote paras)">
       <x:context select="(/h:section[@id='second_ch']//h:span[@data-type='footnote'])[2]" mode="generate.footnote">
 	<x:param name="process.footnotes" select="1"/>
+	<x:param name="process.footnote.callouts.only" select="0"/>
 	<x:param name="footnote.reset.numbering.at.chapter.level" select="0"/>
       </x:context>
       <x:expect label="Footnote should be processed to a para with anchor and proper number">
@@ -1554,6 +1595,7 @@ sect5:1
     <x:scenario label="With process footnotes enabled and footnote.reset.numbering.at.chapter.level enabled (end-of-section footnote paras)">
       <x:context select="(/h:section[@id='second_ch']//h:span[@data-type='footnote'])[2]" mode="generate.footnote">
 	<x:param name="process.footnotes" select="1"/>
+	<x:param name="process.footnote.callouts.only" select="0"/>
 	<x:param name="footnote.reset.numbering.at.chapter.level" select="1"/>
       </x:context>
       <x:expect label="Footnote should be processed to a para with anchor and proper number">
@@ -1665,6 +1707,7 @@ sect5:1
       <p>And now we've got a second paragraph that has a footnoteref here<a data-type="footnoteref" href="#best_footnote_ever"/></p>
     </x:context>
     
+
     <x:scenario label="With process.footnotes disabled">
       <x:context>
 	<x:param name="process.footnotes" select="0"/>


### PR DESCRIPTION
New process.footnote.callouts.only parameter, which lets you generate footnote callout markers, but leave footnote content in place. If you set `process.footnote.callouts` to `1`, then the following footnote markup in source:

````html
<span data-type="footnote">First footnote</span>
````

Will be transformed to the following output:

````html
<sup><a data-type="noteref" id="idm336150198368-marker" href="#idm336150198368">1</a></sup><span data-type="footnote" id="idm336150198368" data-footnote-marker="1">First footnote</span>
````

This makes it possible to autogenerate the "footnote call" markup in place in the body text, while leaving the footnote content in place as well. Potentially useful in conjunction with Paged Media CSS where you want to float the footnote content to the bottom of a page, but still want to rely on XSL to generate the footnote calls.