### PR TITLE
Adding support for three frequently used xrefstyles

### DIFF
--- a/htmlbook-xsl/chunk.xsl
+++ b/htmlbook-xsl/chunk.xsl
@@ -390,7 +390,11 @@ sect5:s
 	      <xsl:variable name="target" select="key('id', $href-anchor)[1]"/>
 	      <xsl:apply-templates select="$target" mode="xref-to">
 		<xsl:with-param name="referrer" select="."/>
-		<xsl:with-param name="xrefstyle" select="@data-xrefstyle"/>
+		  <xsl:with-param name="xrefstyle">
+		    <xsl:call-template name="calculate-xrefstyle">
+		      <xsl:with-param name="data-xrefstyle-attr" select="@data-xrefstyle"/>
+		    </xsl:call-template>
+		  </xsl:with-param>
 	      </xsl:apply-templates>
 	    </xsl:when>
 	    <!-- We can't locate the target; fall back on ??? -->

--- a/htmlbook-xsl/common.xsl
+++ b/htmlbook-xsl/common.xsl
@@ -632,6 +632,12 @@
     <xsl:param name="xref.elements.pagenum.in.class" select="$xref.elements.pagenum.in.class"/>
     <xsl:param name="xref.target"/>
     <xsl:choose>
+      <!-- If select:nopage is specified on element, don't add a pagenum value -->
+      <xsl:when test="starts-with(@data-xrefstyle, 'select:') and contains(substring-after(@data-xrefstyle, 'select:'), 'nopage')">
+	<xsl:if test="$class != ''">
+	  <xsl:value-of select="$class"/>
+	</xsl:if>
+      </xsl:when>
       <!-- If there's an xref target, process that to determine whether a pagenum value should be added to the class -->
       <xsl:when test="$xref.target">
 	<xsl:variable name="xref.target.semantic.name">

--- a/htmlbook-xsl/xrefgen.xsl
+++ b/htmlbook-xsl/xrefgen.xsl
@@ -56,7 +56,11 @@
 		</xsl:apply-templates>
 		<xsl:apply-templates select="$target" mode="xref-to">
 		  <xsl:with-param name="referrer" select="."/>
-		  <xsl:with-param name="xrefstyle" select="@data-xrefstyle"/>
+		  <xsl:with-param name="xrefstyle">
+		    <xsl:call-template name="calculate-xrefstyle">
+		      <xsl:with-param name="data-xrefstyle-attr" select="@data-xrefstyle"/>
+		    </xsl:call-template>
+		  </xsl:with-param>
 		</xsl:apply-templates>
 	      </xsl:when>
 	      <!-- We can't locate the target; fall back on ??? -->
@@ -300,7 +304,13 @@
 
   <xsl:variable name="context">
     <xsl:choose>
-      <!-- If we're XREFing a section or a part div, use the $xref.type.for.section.by.data-type variable -->
+      <!-- First, allow $xrefstyle to override standard xref-type handling -->
+      <xsl:when test="($xrefstyle = 'xref-number-and-title' and $number-and-title-template != 0) or
+		      ($xrefstyle = 'xref-number' and $number-template != 0) or
+		      ($xrefstyle = 'xref')">
+	<xsl:value-of select="$xrefstyle"/>
+      </xsl:when>
+      <!-- Otherwise, if we're XREFing a section or a part div, use the $xref.type.for.section.by.data-type variable -->
       <xsl:when test="self::h:section or self::h:div[contains(@data-type, 'part')]">
 	<xsl:variable name="xref-type">
 	  <xsl:call-template name="get-param-value-from-key">
@@ -684,6 +694,19 @@
     </xsl:otherwise>
   </xsl:choose>
 </xsl:template>
+
+  <!-- Template to calculate xrefstyle from data-xrefstyle attribute -->
+  <xsl:template name="calculate-xrefstyle">
+    <xsl:param name="data-xrefstyle-attr"/>
+    <!-- Currently support the following enumerated custom xrefstyles -->
+    <xsl:choose>
+      <!-- select: labelnumber -->
+      <xsl:when test="starts-with($data-xrefstyle-attr, 'select:') and 
+		      contains(substring-after($data-xrefstyle-attr, 'select:'), 'labelnumber')">template:%n</xsl:when>
+      <!-- chap-num-title -->
+      <xsl:when test="$data-xrefstyle-attr = 'chap-num-title'">xref-number-and-title</xsl:when>
+    </xsl:choose>
+  </xsl:template>
 
   <!-- Template to trim http:// and http://www from URLs -->
   <xsl:template name="trim-url">

--- a/htmlbook-xsl/xspec/chunk.xspec
+++ b/htmlbook-xsl/xspec/chunk.xspec
@@ -590,6 +590,11 @@ toc:lower-roman
 	  </figure>
 	  <p>See <a href="#awesome_squared_fig" id="labelnumber-xref" data-type="xref" data-xrefstyle="select: labelnumber"/> for lots of awesomeness.</p>
 	  <p>See <a href="#awesome_chap" id="chap-num-title-xref" data-type="xref" data-xrefstyle="chap-num-title"/> for awesomeness.</p>
+	  <p>See <a href="#awesome_sect1" id="nopage-xref" data-type="xref" data-xrefstyle="select:nopage"/> for yet more awesomeness</p>
+	</section>
+	<section id="awesome_sect1" data-type="sect1">
+	  <h1>AWESOME SUBSECTION</h1>
+	  <p>I'm here only as an XREF referent.</p>
 	</section>
       </body>
     </x:context>
@@ -602,6 +607,13 @@ toc:lower-roman
     <x:scenario label="of 'chap-num-title'">
       <x:context select="//h:a[@id='chap-num-title-xref']"/>
       <x:expect label="it should return chapter label, number, and title"><a href="#awesome_chap" id="chap-num-title-xref" data-type="xref" data-xrefstyle="chap-num-title">Chapter&#xa0;1, <em>AWESOME CHAPTER</em></a></x:expect>
+    </x:scenario>
+
+    <x:scenario label="of 'select:nopage'">
+      <x:context select="//h:a[@id='nopage-xref']">
+	<x:param name="xref.elements.pagenum.in.class">sect1</x:param>
+      </x:context>
+      <x:expect label="it should return an XREF as usual, but without a pagenum class"><a href="#awesome_sect1" id="nopage-xref" data-xrefstyle="select:nopage" data-type="xref">&#x201c;AWESOME SUBSECTION&#x201d;</a></x:expect>
     </x:scenario>
 
     <x:scenario label="of 'chap-num-title' (localization other than 'en')"

--- a/htmlbook-xsl/xspec/chunk.xspec
+++ b/htmlbook-xsl/xspec/chunk.xspec
@@ -572,6 +572,45 @@ toc:lower-roman
     </x:scenario>
   </x:scenario>
 
+  <!-- Tests for data-xrefstyle attribute -->
+  <x:scenario label="When an XREF is matched with data-xrefstyle...">
+    <x:context>
+      <body>
+	<section data-type="chapter" id="awesome_chap">
+	  <h1>AWESOME CHAPTER</h1>
+	  <p>Check out this pic:</p>
+	  <figure>
+	    <figcaption>AWESOME PIC</figcaption>
+	    <img alt="awesomeness" src="awesomeness.png"/>
+	  </figure>
+	  <p>And this one, too:</p>
+	  <figure id="awesome_squared_fig">
+	    <figcaption>AWESOMENESS SQUARED</figcaption>
+	    <img alt="awesomeness to the second power" src="awesomenesssquared.png"/>
+	  </figure>
+	  <p>See <a href="#awesome_squared_fig" id="labelnumber-xref" data-type="xref" data-xrefstyle="select: labelnumber"/> for lots of awesomeness.</p>
+	  <p>See <a href="#awesome_chap" id="chap-num-title-xref" data-type="xref" data-xrefstyle="chap-num-title"/> for awesomeness.</p>
+	</section>
+      </body>
+    </x:context>
+
+    <x:scenario label="of 'select: labelnumber'">
+      <x:context select="//h:a[@id='labelnumber-xref']"/>
+      <x:expect label="it should return just the label number"><a href="#awesome_squared_fig" id="labelnumber-xref" data-type="xref" data-xrefstyle="select: labelnumber">1-2</a></x:expect>
+    </x:scenario>
+
+    <x:scenario label="of 'chap-num-title'">
+      <x:context select="//h:a[@id='chap-num-title-xref']"/>
+      <x:expect label="it should return chapter label, number, and title"><a href="#awesome_chap" id="chap-num-title-xref" data-type="xref" data-xrefstyle="chap-num-title">Chapter&#xa0;1, <em>AWESOME CHAPTER</em></a></x:expect>
+    </x:scenario>
+
+    <x:scenario label="of 'chap-num-title' (localization other than 'en')"
+		pending="No clean way to parameterize language at template level for unit tests yet">
+      <x:expect label="FILL ME IN LATER" select="'FILL ME IN LATER'"/>
+    </x:scenario>
+    
+  </x:scenario>
+
   <!-- Tests around "pagenum" classes for XREFs -->
   <x:scenario label="If XREF is matched">
     <x:context>

--- a/htmlbook-xsl/xspec/common.xspec
+++ b/htmlbook-xsl/xspec/common.xspec
@@ -1208,7 +1208,7 @@ sect5:none
     <!-- Not sure XSpec can handle tests that generate just an attribute node, e.g.:
 	  XTDE0420: Cannot create an attribute node (class) whose parent is a document node
       -->
-    <x:scenario label="If an element is matched in class.attribute modee">
+    <x:scenario label="If an element is matched in class.attribute mode">
       <x:context mode="class.attribute"/>
       
     <x:scenario label="and its generated class attribute (via class.value) is empty">
@@ -1241,6 +1241,8 @@ sect5:none
 	    <p>Sidebar text</p>
 	  </aside>
 	  <p>XREF to the sect1 in second chapter: see <a id="sect1_xref" data-type="xref" href="#chapter2_sect1"/></p>
+	  <p>Same XREF as above, but with pagenumber suppressed: see <a id="sect1_xref_nopage" data-type="xref" href="#chapter2_sect1" data-xrefstyle="select:nopage"/></p>
+	  <p>Same XREF as above, different xrefstyle formatting: see <a id="sect1_xref_nopage2" class="underline" data-type="xref" href="#chapter2_sect1" data-xrefstyle="select: nopage"/></p>
 	</section>
 	<section data-type="chapter" id="second">
 	  <h1>Second chapter</h1>
@@ -1293,6 +1295,48 @@ sect1
       </x:context>
       <x:expect label="Class value of 'pagenum' *should not* be added. Class value preserved as is">underline</x:expect>
     </x:scenario>
+
+    <!-- xrefstyle handling -->
+    <x:scenario label="that points to an element *not* in the xref.elements.pagenum.in.class list, and with select:nopage specified as xrefstyle">
+      <x:context select="//h:a[@data-type='xref'][@id='sect1_xref_nopage']">
+	<x:param name="xref.elements.pagenum.in.class">chapter
+sidebar
+	</x:param>
+	<x:param name="xref.target" select="//h:section[@id='chapter2_sect1']"/>
+      </x:context>
+      <x:expect label="Class value of 'pagenum' should not be appended" select="()"/>
+    </x:scenario>
+
+    <x:scenario label="that points to an element in the xref.elements.pagenum.in.class list, but with select:nopage specified as xrefstyle">
+      <x:context select="//h:a[@data-type='xref'][@id='sect1_xref_nopage']">
+	<x:param name="xref.elements.pagenum.in.class">chapter
+sect1
+	</x:param>
+	<x:param name="xref.target" select="//h:section[@id='chapter2_sect1']"/>
+      </x:context>
+      <x:expect label="Class value of 'pagenum' should not be appended" select="()"/>
+    </x:scenario>
+
+    <x:scenario label="that points to an element *not* in the xref.elements.pagenum.in.class list, and with select: nopage specified as xrefstyle">
+      <x:context select="//h:a[@data-type='xref'][@id='sect1_xref_nopage2']">
+	<x:param name="xref.elements.pagenum.in.class">chapter
+sidebar
+	</x:param>
+	<x:param name="xref.target" select="//h:section[@id='chapter2_sect1']"/>
+      </x:context>
+      <x:expect label="Class value of 'pagenum' should not be appended">underline</x:expect>
+    </x:scenario>
+
+    <x:scenario label="that points to an element in the xref.elements.pagenum.in.class list, but with select: nopage specified as xrefstyle">
+      <x:context select="//h:a[@data-type='xref'][@id='sect1_xref_nopage2']">
+	<x:param name="xref.elements.pagenum.in.class">chapter
+sect1
+	</x:param>
+	<x:param name="xref.target" select="//h:section[@id='chapter2_sect1']"/>
+      </x:context>
+      <x:expect label="Class value of 'pagenum' should not be appended">underline</x:expect>
+    </x:scenario>
+
 
   </x:scenario>
 

--- a/htmlbook-xsl/xspec/xrefgen.xspec
+++ b/htmlbook-xsl/xspec/xrefgen.xspec
@@ -1216,6 +1216,11 @@ sidebar
 	  </figure>
 	  <p>See <a href="#awesome_squared_fig" id="labelnumber-xref" data-type="xref" data-xrefstyle="select: labelnumber"/> for lots of awesomeness.</p>
 	  <p>See <a href="#awesome_chap" id="chap-num-title-xref" data-type="xref" data-xrefstyle="chap-num-title"/> for awesomeness.</p>
+	  <p>See <a href="#awesome_sect1" id="nopage-xref" data-type="xref" data-xrefstyle="select:nopage"/> for yet more awesomeness</p>
+	  <section id="awesome_sect1" data-type="sect1">
+	    <h1>AWESOME SUBSECTION</h1>
+	    <p>I'm here only as an XREF referent.</p>
+	  </section>
 	</section>
       </body>
     </x:context>
@@ -1228,6 +1233,13 @@ sidebar
     <x:scenario label="of 'chap-num-title'">
       <x:context select="//h:a[@id='chap-num-title-xref']"/>
       <x:expect label="it should return chapter label, number, and title"><a href="#awesome_chap" id="chap-num-title-xref" data-type="xref" data-xrefstyle="chap-num-title" data-xref-pagenum-style="...">Chapter&#xa0;1, <em>AWESOME CHAPTER</em></a></x:expect>
+    </x:scenario>
+
+    <x:scenario label="of 'select:nopage'">
+      <x:context select="//h:a[@id='nopage-xref']">
+	<x:param name="xref.elements.pagenum.in.class">sect1</x:param>
+      </x:context>
+      <x:expect label="it should return an XREF as usual, but without a pagenum class"><a href="#awesome_sect1" id="nopage-xref" data-xref-pagenum-style="..." data-xrefstyle="select:nopage" data-type="xref">&#x201c;AWESOME SUBSECTION&#x201d;</a></x:expect>
     </x:scenario>
 
     <x:scenario label="of 'chap-num-title' (localization other than 'en')"

--- a/htmlbook-xsl/xspec/xrefgen.xspec
+++ b/htmlbook-xsl/xspec/xrefgen.xspec
@@ -1226,16 +1226,16 @@ sidebar
     </x:scenario>
 
     <x:scenario label="of 'chap-num-title'">
-      <x:context select="//h:a[@id='labelnumber-xref']"/>
-      <x:expect label="it should return chapter label, number, and title"><a href="#awesome_chap" id="labelnumber-xref" data-type="xref" data-xrefstyle="select: labelnumber" data-xref-pagenum-style="...">Chapter&#xa0;1, <em>AWESOME CHAPTER</em></a></x:expect>
+      <x:context select="//h:a[@id='chap-num-title-xref']"/>
+      <x:expect label="it should return chapter label, number, and title"><a href="#awesome_chap" id="chap-num-title-xref" data-type="xref" data-xrefstyle="chap-num-title" data-xref-pagenum-style="...">Chapter&#xa0;1, <em>AWESOME CHAPTER</em></a></x:expect>
     </x:scenario>
 
-  <x:scenario label="of 'chap-num-title' (localization other than 'en')"
-	      pending="No way to parameterize language locally yet for XSpec testing"/> 
+    <x:scenario label="of 'chap-num-title' (localization other than 'en')"
+		pending="No clean way to parameterize language at template level for unit tests yet">
+      <x:expect label="FILL ME IN LATER" select="'FILL ME IN LATER'"/>
+    </x:scenario>
     
   </x:scenario>
-
-
 
   <!-- Tests for whether an HREF is considered to be an XREF (link within the same corpus) -->
   <x:scenario label="If an href starts with a '#'">
@@ -1356,21 +1356,21 @@ sidebar
     <x:call template="calculate-xrefstyle">
       <x:param name="data-xrefstyle-attr">chap-num-title</x:param>
     </x:call>
-    <x:expect label="Proper template should be generated">template:Chapter&#xa0;%n, %t</x:expect>
+    <x:expect label="Proper template should be generated">xref-number-and-title</x:expect>
   </x:scenario>
 
   <x:scenario label="If calculate-xrefstyle is called on xrefstyle that does not match an enumerated pattern">
     <x:call template="calculate-xrefstyle">
       <x:param name="data-xrefstyle-attr">bogus_xrefstyle_yo</x:param>
     </x:call>
-    <x:expect label="Result should be empty" select="''"/>
+    <x:expect label="Result should be empty" select="()"/>
   </x:scenario>
 
   <x:scenario label="If calculate-xrefstyle is called on xrefstyle value that is empty">
     <x:call template="calculate-xrefstyle">
       <x:param name="data-xrefstyle-attr" select="''"/>
     </x:call>
-    <x:expect label="Result should be empty" select="''"/>
+    <x:expect label="Result should be empty" select="()"/>
   </x:scenario>
   
   <!-- Tests for trim url template -->

--- a/htmlbook-xsl/xspec/xrefgen.xspec
+++ b/htmlbook-xsl/xspec/xrefgen.xspec
@@ -1198,6 +1198,45 @@ sidebar
     <x:expect label="should return the default xref-pagenum-style of decimal">decimal</x:expect>
   </x:scenario>
 
+  <!-- Tests for data-xrefstyle attribute -->
+  <x:scenario label="When an XREF is matched with data-xrefstyle...">
+    <x:context>
+      <body>
+	<section data-type="chapter" id="awesome_chap">
+	  <h1>AWESOME CHAPTER</h1>
+	  <p>Check out this pic:</p>
+	  <figure>
+	    <figcaption>AWESOME PIC</figcaption>
+	    <img alt="awesomeness" src="awesomeness.png"/>
+	  </figure>
+	  <p>And this one, too:</p>
+	  <figure id="awesome_squared_fig">
+	    <figcaption>AWESOMENESS SQUARED</figcaption>
+	    <img alt="awesomeness to the second power" src="awesomenesssquared.png"/>
+	  </figure>
+	  <p>See <a href="#awesome_squared_fig" id="labelnumber-xref" data-type="xref" data-xrefstyle="select: labelnumber"/> for lots of awesomeness.</p>
+	  <p>See <a href="#awesome_chap" id="chap-num-title-xref" data-type="xref" data-xrefstyle="chap-num-title"/> for awesomeness.</p>
+	</section>
+      </body>
+    </x:context>
+
+    <x:scenario label="of 'select: labelnumber'">
+      <x:context select="//h:a[@id='labelnumber-xref']"/>
+      <x:expect label="it should return just the label number"><a href="#awesome_squared_fig" id="labelnumber-xref" data-type="xref" data-xrefstyle="select: labelnumber" data-xref-pagenum-style="...">1-2</a></x:expect>
+    </x:scenario>
+
+    <x:scenario label="of 'chap-num-title'">
+      <x:context select="//h:a[@id='labelnumber-xref']"/>
+      <x:expect label="it should return chapter label, number, and title"><a href="#awesome_chap" id="labelnumber-xref" data-type="xref" data-xrefstyle="select: labelnumber" data-xref-pagenum-style="...">Chapter&#xa0;1, <em>AWESOME CHAPTER</em></a></x:expect>
+    </x:scenario>
+
+  <x:scenario label="of 'chap-num-title' (localization other than 'en')"
+	      pending="No way to parameterize language locally yet for XSpec testing"/> 
+    
+  </x:scenario>
+
+
+
   <!-- Tests for whether an HREF is considered to be an XREF (link within the same corpus) -->
   <x:scenario label="If an href starts with a '#'">
     <x:call template="href-is-xref">
@@ -1296,6 +1335,42 @@ sidebar
       <x:param name="source-href-value" select="'why_would_you#do_this#idonotknow'"/>
     </x:call>
     <x:expect label="Output the content from the *last* # sign to the end">#idonotknow</x:expect>
+  </x:scenario>
+
+  <!-- Tests for calculate-xrefstyle template -->
+  <x:scenario label="If calculate-xrefstyle is called on xrefstyle of 'select: labelnumber'">
+    <x:call template="calculate-xrefstyle">
+      <x:param name="data-xrefstyle-attr">select: labelnumber</x:param>
+    </x:call>
+    <x:expect label="Proper template should be generated">template:%n</x:expect>
+  </x:scenario>
+
+  <x:scenario label="If calculate-xrefstyle is called on xrefstyle of 'select:labelnumber'">
+    <x:call template="calculate-xrefstyle">
+      <x:param name="data-xrefstyle-attr">select: labelnumber</x:param>
+    </x:call>
+    <x:expect label="Proper template should be generated">template:%n</x:expect>
+  </x:scenario>
+
+  <x:scenario label="If calculate-xrefstyle is called on xrefstyle of chap-num-title">
+    <x:call template="calculate-xrefstyle">
+      <x:param name="data-xrefstyle-attr">chap-num-title</x:param>
+    </x:call>
+    <x:expect label="Proper template should be generated">template:Chapter&#xa0;%n, %t</x:expect>
+  </x:scenario>
+
+  <x:scenario label="If calculate-xrefstyle is called on xrefstyle that does not match an enumerated pattern">
+    <x:call template="calculate-xrefstyle">
+      <x:param name="data-xrefstyle-attr">bogus_xrefstyle_yo</x:param>
+    </x:call>
+    <x:expect label="Result should be empty" select="''"/>
+  </x:scenario>
+
+  <x:scenario label="If calculate-xrefstyle is called on xrefstyle value that is empty">
+    <x:call template="calculate-xrefstyle">
+      <x:param name="data-xrefstyle-attr" select="''"/>
+    </x:call>
+    <x:expect label="Result should be empty" select="''"/>
   </x:scenario>
   
   <!-- Tests for trim url template -->


### PR DESCRIPTION
This PR adds support analogous to that provided in DocBook-XSL for six frequently used XREF styles:

* `select:labelnumber` (print just the label number for the XREF referent, i.e. `template:%n`
* `chap-num-title` (print chapter label and title for XREF chapter referents, i.e. `template:Chapter %n, %t`)
* `select:nopage` (don't add pagenum class to XREF, so page number will be suppressed in paged outputs)

All of the above xrefstyles should be added to a `data-xrefstyle` attribute on the XREF `<a>` element, e.g.:

````html
See Figures <a data-type="xref" data-xrefstyle="select:labelnumber" href="#fig"/> 
and <a data-type="xref" data-xrefstyle="select:labelnumber" href="#fig2"/>
````



