### PR TITLE
Adding support for code-listing line numbering

### DIFF
--- a/htmlbook-xsl/elements.xsl
+++ b/htmlbook-xsl/elements.xsl
@@ -307,7 +307,7 @@
   <xsl:template match="h:pre[@data-type='programlisting']">
     <xsl:param name="number.code.lines" select="$number.code.lines"/>
     <xsl:choose>
-      <xsl:when test="$number.code.lines = 1">
+      <xsl:when test="$number.code.lines = 1 or @data-line-numbering='numbered'">
 	<xsl:variable name="code-listing">
 	  <xsl:copy>
 	    <xsl:apply-templates select="@*|node()" mode="add.numbering.placeholders"/>

--- a/htmlbook-xsl/elements.xsl
+++ b/htmlbook-xsl/elements.xsl
@@ -303,6 +303,73 @@
     </xsl:copy>
   </xsl:template>
 
+  <!-- Programlisting handling -->
+  <xsl:template match="h:pre[@data-type='programlisting']">
+    <xsl:param name="number.code.lines" select="$number.code.lines"/>
+    <xsl:choose>
+      <xsl:when test="$number.code.lines = 1">
+	<xsl:variable name="code-listing">
+	  <xsl:copy>
+	    <xsl:apply-templates select="@*|node()" mode="add.numbering.placeholders"/>
+	  </xsl:copy>
+	</xsl:variable>
+	<xsl:apply-templates select="exsl:node-set($code-listing)" mode="number.code.lines"/>
+      </xsl:when>
+      <xsl:otherwise>
+	<xsl:copy>
+	  <xsl:apply-templates select="@*|node()"/>
+	</xsl:copy>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <!-- Default template for add.numbering.placeholders to ensure all content is copied over -->
+  <xsl:template match="@*|node()" mode="add.numbering.placeholders">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()" mode="add.numbering.placeholders"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="h:pre[@data-type='programlisting']//text()" mode="add.numbering.placeholders">
+      <!-- Check if this is the very first text node in the code listing; if so, add span numbering placeholder at the beginning -->
+      <xsl:if test="not(ancestor::h:pre[1]//text()[following::*[. = current()]])"><span class="line-number"/></xsl:if>
+      <!-- Then add line numbering for each newline -->
+      <xsl:call-template name="add-line-numbering-markup-at-newlines"/>
+  </xsl:template>
+
+  <xsl:template name="add-line-numbering-markup-at-newlines">
+    <xsl:param name="text" select="."/>
+    <xsl:choose>
+      <xsl:when test="substring-before($text, '&#xa;')">
+	<xsl:value-of select="substring-before($text, '&#xa;')"/>
+	<xsl:text>&#xa;</xsl:text>
+	<span class="line-number"/>
+	<xsl:call-template name="add-line-numbering-markup-at-newlines">
+	  <xsl:with-param name="text" select="substring-after($text, '&#xa;')"/>
+	</xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+	<xsl:value-of select="$text"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <!-- Default template for number.code.lines to ensure all content is copied over -->
+  <xsl:template match="@*|node()" mode="number.code.lines">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()" mode="number.code.lines"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Add number and a space to spans with class "line-number" -->
+  <xsl:template match="h:span[@class='line-number']" mode="number.code.lines">
+    <xsl:copy>
+      <xsl:apply-templates select="@*"/>
+      <xsl:number count="h:span[@class='line-number']" level="any" from="h:pre[@data-type='programlisting']"/>
+      <xsl:text> </xsl:text>
+    </xsl:copy>
+  </xsl:template>
+
   <!-- Footnote handling -->
   <xsl:template match="h:span[@data-type='footnote']">
     <xsl:param name="footnote.reset.numbering.at.chapter.level" select="$footnote.reset.numbering.at.chapter.level"/>

--- a/htmlbook-xsl/elements.xsl
+++ b/htmlbook-xsl/elements.xsl
@@ -339,8 +339,8 @@
 
   <xsl:template name="add-line-numbering-markup-at-newlines">
     <xsl:param name="text" select="."/>
-    <xsl:choose>
-      <xsl:when test="substring-before($text, '&#xa;')">
+    <xsl:choose>      
+      <xsl:when test="substring-before($text, '&#xa;') or substring($text, 1, 1) = '&#xa;'">
 	<xsl:value-of select="substring-before($text, '&#xa;')"/>
 	<xsl:text>&#xa;</xsl:text>
 	<span class="line-number"/>

--- a/htmlbook-xsl/param.xsl
+++ b/htmlbook-xsl/param.xsl
@@ -172,6 +172,11 @@ toc:lower-roman
   <!-- Render @href text in parens following <a> element for external hyperlinks; useful for print outputs -->
   <xsl:param name="url.in.parens" select="1"/>
 
+  <!-- Code-specific params -->
+
+  <!-- Add line numbers to code listings globally -->
+  <xsl:param name="number.code.lines" select="0"/>
+
   <!-- Footnote-specific params -->
 
   <!-- Process footnotes into separate marker/hyperlink and footnote content, and move to end of sections -->

--- a/htmlbook-xsl/xspec/elements.xspec
+++ b/htmlbook-xsl/xspec/elements.xspec
@@ -1470,6 +1470,34 @@ end</pre>
 <span class="line-number">13 </span>end</pre>
       </x:expect>
   </x:scenario>
+    
+  <x:scenario label="with global line numbering enabled (blank lines in listing">
+    <x:context>
+      <x:param name="number.code.lines" select="1"/>
+      <pre data-type="programlisting" data-code-language="java" data-line-numbering="numbered">import java.applet.*;
+import java.awt.*;
+
+public class Scribble extends Applet {
+    private int last_x = 0;
+    private int last_y = 0;
+    private Color current_color = Color.black;
+    private Button clear_button;
+    private Choice color_choices;</pre>
+    </x:context>
+    
+    <x:expect label="Code line numbers should be added">
+      <pre data-type="programlisting" data-code-language="java" data-line-numbering="numbered"><span class="line-number">1 </span>import java.applet.*;
+<span class="line-number">2 </span>import java.awt.*;
+<span class="line-number">3 </span>
+<span class="line-number">4 </span>public class Scribble extends Applet {
+<span class="line-number">5 </span>    private int last_x = 0;
+<span class="line-number">6 </span>    private int last_y = 0;
+<span class="line-number">7 </span>    private Color current_color = Color.black;
+<span class="line-number">8 </span>    private Button clear_button;
+<span class="line-number">9 </span>    private Choice color_choices;</pre>
+    </x:expect>
+    
+  </x:scenario>
 
     <x:scenario label="with global line numbering disabled but data-linenumbering enabled for the individual listing">
       <x:context>

--- a/htmlbook-xsl/xspec/elements.xspec
+++ b/htmlbook-xsl/xspec/elements.xspec
@@ -1409,6 +1409,68 @@ sect5:1
       </x:expect>
     </x:scenario>
   </x:scenario>
+  
+  <x:scenario label="When matching a 'pre'">
+    <x:context>
+      <pre data-type="programlisting">def self.compile_file(filename, *args)
+    options = args.last.is_a?(Hash) ? args.pop : {}
+    css_filename = args.shift
+    result = Sass::Engine.for_file(filename, options).render
+    if css_filename
+      options[:css_filename] ||= css_filename
+      open(css_filename, "w") {|css_file| css_file.write(result)}
+      nil
+    else
+      result
+    end
+  end
+end</pre>
+    </x:context>
+    
+    <x:scenario label="with global code line numbering disabled">
+      <x:context>
+        <x:param name="number.code.lines" select="0"/>
+      </x:context>
+    
+    <x:expect label="Content should be passed through as is">
+      <pre data-type="programlisting">def self.compile_file(filename, *args)
+    options = args.last.is_a?(Hash) ? args.pop : {}
+    css_filename = args.shift
+    result = Sass::Engine.for_file(filename, options).render
+    if css_filename
+      options[:css_filename] ||= css_filename
+      open(css_filename, "w") {|css_file| css_file.write(result)}
+      nil
+    else
+      result
+    end
+  end
+end</pre>
+    </x:expect>
+    </x:scenario>
+      
+    <x:scenario label="with global line numbering enabled">
+      <x:context>
+        <x:param name="number.code.lines" select="1"/>
+      </x:context>
+      
+      <x:expect label="Code line numbers should be added">
+        <pre data-type="programlisting"><span class="line-number">1 </span>def self.compile_file(filename, *args)
+<span class="line-number">2 </span>    options = args.last.is_a?(Hash) ? args.pop : {}
+<span class="line-number">3 </span>    css_filename = args.shift
+<span class="line-number">4 </span>    result = Sass::Engine.for_file(filename, options).render
+<span class="line-number">5 </span>    if css_filename
+<span class="line-number">6 </span>      options[:css_filename] ||= css_filename
+<span class="line-number">7 </span>      open(css_filename, "w") {|css_file| css_file.write(result)}
+<span class="line-number">8 </span>      nil
+<span class="line-number">9 </span>    else
+<span class="line-number">10 </span>      result
+<span class="line-number">11 </span>    end
+<span class="line-number">12 </span>  end
+<span class="line-number">13 </span>end</pre>
+      </x:expect>
+  </x:scenario>
+</x:scenario>
 
   <x:scenario label="When matching any 'figcaption'">
     <x:context>

--- a/htmlbook-xsl/xspec/elements.xspec
+++ b/htmlbook-xsl/xspec/elements.xspec
@@ -1470,6 +1470,30 @@ end</pre>
 <span class="line-number">13 </span>end</pre>
       </x:expect>
   </x:scenario>
+
+    <x:scenario label="with global line numbering disabled but data-linenumbering enabled for the individual listing">
+      <x:context>
+        <x:param name="number.code.lines" select="0"/>
+        <pre data-type="programlisting" data-line-numbering="numbered">if css_filename
+  options[:css_filename] ||= css_filename
+  open(css_filename, "w") {|css_file| css_file.write(result)}
+  nil
+else
+  result
+end</pre>
+      </x:context>
+      
+      <x:expect label="Code line numbers should be added">
+        <pre data-type="programlisting" data-line-numbering="numbered"><span class="line-number">1 </span>if css_filename
+<span class="line-number">2 </span>  options[:css_filename] ||= css_filename
+<span class="line-number">3 </span>  open(css_filename, "w") {|css_file| css_file.write(result)}
+<span class="line-number">4 </span>  nil
+<span class="line-number">5 </span>else
+<span class="line-number">6 </span>  result
+<span class="line-number">7 </span>end</pre>
+      </x:expect>
+    </x:scenario>
+
 </x:scenario>
 
   <x:scenario label="When matching any 'figcaption'">


### PR DESCRIPTION
Added handling to toggle on line numbering for code listings, e.g., change the following:

````html
<pre data-type="programlisting" data-line-numbering="numbered">if css_filename
  options[:css_filename] ||= css_filename
  open(css_filename, "w") {|css_file| css_file.write(result)}
  nil
else
  result
end</pre>
````

to:

````html
<pre data-type="programlisting" data-line-numbering="numbered"><span class="line-number">1 </span>if css_filename
<span class="line-number">2 </span>  options[:css_filename] ||= css_filename
<span class="line-number">3 </span>  open(css_filename, "w") {|css_file| css_file.write(result)}
<span class="line-number">4 </span>  nil
<span class="line-number">5 </span>else
<span class="line-number">6 </span>  result
<span class="line-number">7 </span>end</pre>
````

Line numbering can be turned on in one of two ways:

* Globally by setting:

````
<xsl:param name="number.code.lines" select="1"/>
````

* On individual code listings by adding the attribute `data-line-numbering="numbered"` à la DocBook XML.

All line numbers are wrapped in `<span class="line-number">` to facilitate styling via CSS if desired.