### PR TITLE
Updating xref-to behavior for div refentry. 

### DIFF
--- a/htmlbook-xsl/xrefgen.xsl
+++ b/htmlbook-xsl/xrefgen.xsl
@@ -201,7 +201,7 @@
   </xsl:template>
 
   <!-- Special xref-to handling for refentries -->
-  <xsl:template match="h:div[@class='refentry']" mode="xref-to">
+  <xsl:template match="h:div[contains(@class,'refentry')]" mode="xref-to">
     <xsl:choose>
       <xsl:when test="descendant::*[@class='refname']">
 	<!-- Choose the first descendant element with class of refname, if one exists, and wrap in "code" tag -->

--- a/htmlbook-xsl/xspec/xrefgen.xspec
+++ b/htmlbook-xsl/xspec/xrefgen.xspec
@@ -202,6 +202,26 @@ toc:lower-roman
   
   </x:scenario>
   
+  <x:scenario label="When an XREF points to a refentry that has other roles">
+    <x:context mode="xref-to">
+      <div class="refentry pagebreak-before refentry_nospace">
+        <header>
+          <p class="refname">print</p>
+          <p class="refpurpose">Output some text to stdout.</p>
+        </header>
+        <div class="refsynopsisdiv">
+          <pre class="synopsis">print "<em>Hello World</em>"</pre>
+        </div>
+        <div class="refsect1">
+          <h6>Description</h6>
+          <p>More description would go here</p>
+        </div>
+      </div>
+    </x:context>
+    <x:expect label="Generated text should be refname tagged as code"><code class="refentry">print</code></x:expect>
+    
+  </x:scenario>
+  
   <x:scenario label="When an XREF points to a refentry without a refname 'p'">
     <x:context mode="xref-to">
       <div class="refentry">


### PR DESCRIPTION
Now checks if the divs class contains "refentry" instead of being equal to it. This prevents refentry divs with other classes from not being matched. Also, adding an extra xspec test for this new behavior.