### PR TITLE
Use generic url

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <title>HTMLBook</title>
     <meta charset="utf-8">
-    <script src="http://www.w3.org/Tools/respec/respec-w3c-common" async class="remove"></script>
+    <script src="//www.w3.org/Tools/respec/respec-w3c-common" async class="remove"></script>
     <script class="remove">
       var respecConfig = {
           additionalCopyrightHolders: "Copyright &copy; 2014 O&#x2019;Reilly Media, Inc.",


### PR DESCRIPTION
Fixes mix content warning and unstyled page. 

**`w3.org`** has HTTPS support.

> [![Mix Content warning](http://i.imgur.com/k6Wsr0f.png)](http://i.imgur.com/k6Wsr0f.png)