### PR TITLE
Add support for the "version" attribute in the SVG schema

### DIFF
--- a/schema/svg/SVG.xsd
+++ b/schema/svg/SVG.xsd
@@ -1102,6 +1102,7 @@
     <attribute name="style" type="svg:StyleSheetType" use="optional"/>
     <attributeGroup ref="svg:PresentationAttributes-All"/>
     <attribute name="viewBox" type="svg:ViewBoxSpecType" use="optional"/>
+    <attribute name="version" type="double" use="optional"/>
     <attribute name="preserveAspectRatio" type="svg:PreserveAspectRatioSpecType" default="xMidYMid meet"/>
     <attribute name="zoomAndPan" default="magnify">
       <simpleType>


### PR DESCRIPTION
The "version" attribute is specified by SVG[1] and is used by some
libraries like Cairo[2] in their generated SVG output.

Supporting the "version" attribute in the schema allows to validate
files generated by Cairo with xmllint.

[1] https://www.w3.org/TR/SVG11/struct.html#SVGElementVersionAttribute
[2] https://www.cairographics.org/