### PR TITLE
ATLAS-27: Update XSL to generate files with .xhtml extension

### DIFF
--- a/htmlbook-xsl/chunk.xsl
+++ b/htmlbook-xsl/chunk.xsl
@@ -320,7 +320,7 @@ sect5:s
       <xsl:number count="*[local-name() = $node-name and @data-type = $node-data-type]" format="01"/>
       <xsl:if test="$original-call = 1">
 	<!-- ToDo: Parameterize me to allow use of different filename extension? -->
-	<xsl:text>.html</xsl:text>
+	<xsl:text>.xhtml</xsl:text>
       </xsl:if>
     </xsl:for-each>
   </xsl:template>

--- a/htmlbook-xsl/xspec/fileextension.xspec
+++ b/htmlbook-xsl/xspec/fileextension.xspec
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               xmlns:functx="http://www.functx.com"
+	       xmlns="http://www.w3.org/1999/xhtml"
+	       xmlns:ncx="http://www.daisy.org/z3986/2005/ncx/"
+	       xmlns:h="http://www.w3.org/1999/xhtml"
+	       xmlns:e="http://github.com/oreillymedia/epubrenderer"
+	       xmlns:htmlbook="https://github.com/oreillymedia/HTMLBook"
+               stylesheet="../chunk.xsl">
+
+<x:scenario label="When calling output-filename-for-chunk" pending="We received an  error when trying to run this scenario.
+We were using the Saxon JAR file version SAXON HE 9.5.1.2
+and the script from https://github.com/xspec/xspec.">
+	<x:call template="output-filename-for-chunk">
+		<x:param name="node">
+			<section data-type="chapter"/>
+		</x:param>
+    </x:call>
+    <x:expect label="the file extension should be .xhtml">ch01.xhtml</x:expect>
+</x:scenario>
+
+</x:description>

--- a/htmlbook-xsl/xspec/fileextension.xspec
+++ b/htmlbook-xsl/xspec/fileextension.xspec
@@ -9,9 +9,11 @@
 	       xmlns:htmlbook="https://github.com/oreillymedia/HTMLBook"
                stylesheet="../chunk.xsl">
 
-<x:scenario label="When calling output-filename-for-chunk" pending="We received an  error when trying to run this scenario.
-We were using the Saxon JAR file version SAXON HE 9.5.1.2
-and the script from https://github.com/xspec/xspec.">
+<x:scenario 
+  label="When calling output-filename-for-chunk" 
+  pending="We received an error when trying to run this scenario.
+    We were using the Saxon JAR file version SAXON HE 9.5.1.2
+    and the script from https://github.com/xspec/xspec.">
 	<x:call template="output-filename-for-chunk">
 		<x:param name="node">
 			<section data-type="chapter"/>


### PR DESCRIPTION
This PR has two parts:

1. Changing the file extension generated by output-filename-for-chunk to .xhtml
2. Adding fileextension.xspec to test this change

Thanks,
-Nick