### PR TITLE
ATLAS-206: Update toolchain to generate EPUB cover file with .xhtml extension

### DIFF
--- a/htmlbook-xsl/epub.xsl
+++ b/htmlbook-xsl/epub.xsl
@@ -161,7 +161,7 @@
   </xsl:param>
 
   <!-- Param to specify filename for cover HTML (only applicable if $generate.cover.html is enabled)-->
-  <xsl:param name="cover.html.filename" select="'cover.html'"/>
+  <xsl:param name="cover.html.filename" select="'cover.xhtml'"/>
 
   <!-- Param to specify whether or not to include the cover HTML file in the spine (only applicable if $generate.cover.html is enabled)-->
   <xsl:param name="cover.in.spine" select="1"/>


### PR DESCRIPTION
This is a change to epub.xsl that sets the filename of the autogenerated cover file to "cover.xhtml". The purpose of this is to avoid epubcheck warnings. See https://intranet.oreilly.com/jira/browse/ATLAS-206