### PR TITLE
ATLAS-209: Update toolchain to generate index file with .xhtml extension

### DIFF
--- a/htmlbook-xsl/chunk.xsl
+++ b/htmlbook-xsl/chunk.xsl
@@ -28,7 +28,7 @@
   <xsl:param name="generate.root.chunk" select="0"/>
 
   <!-- Specify the filename for the root chunk, if $generate.root.chunk is enabled -->
-  <xsl:param name="root.chunk.filename" select="'index.html'"/>
+  <xsl:param name="root.chunk.filename" select="'index.xhtml'"/>
 
   <!-- Specify a prefix for output filename for a given data-type -->
   <xsl:param name="output.filename.prefix.by.data-type">


### PR DESCRIPTION
This is a change to chunk.xsl that sets the filename of the autogenerated root chunk file to "index.xhtml". The root chunk file is included if there is no titlepage. The purpose of this is to avoid epubcheck warnings as well as to ensure that the Travis CI tests for the Atlas Workers pass as expected. See https://intranet.oreilly.com/jira/browse/ATLAS-206 and https://github.com/oreillymedia/orm-atlas-workers/pull/281