### PR TITLE
Revert "ATLAS-209: Update toolchain to generate index file with .xhtml extension"

### DIFF
--- a/htmlbook-xsl/chunk.xsl
+++ b/htmlbook-xsl/chunk.xsl
@@ -28,7 +28,7 @@
   <xsl:param name="generate.root.chunk" select="0"/>
 
   <!-- Specify the filename for the root chunk, if $generate.root.chunk is enabled -->
-  <xsl:param name="root.chunk.filename" select="'index.xhtml'"/>
+  <xsl:param name="root.chunk.filename" select="'index.html'"/>
 
   <!-- Specify a prefix for output filename for a given data-type -->
   <xsl:param name="output.filename.prefix.by.data-type">


### PR DESCRIPTION
This has caused unintended consequences on the Platform. Reverting per request from Andrew Odewahn.

Reverts oreillymedia/HTMLBook#224