### PR TITLE
Revert "ATLAS-206: Update toolchain to generate EPUB cover file with .xhtml extension"

### DIFF
--- a/htmlbook-xsl/epub.xsl
+++ b/htmlbook-xsl/epub.xsl
@@ -161,7 +161,7 @@
   </xsl:param>
 
   <!-- Param to specify filename for cover HTML (only applicable if $generate.cover.html is enabled)-->
-  <xsl:param name="cover.html.filename" select="'cover.xhtml'"/>
+  <xsl:param name="cover.html.filename" select="'cover.html'"/>
 
   <!-- Param to specify whether or not to include the cover HTML file in the spine (only applicable if $generate.cover.html is enabled)-->
   <xsl:param name="cover.in.spine" select="1"/>


### PR DESCRIPTION
This has caused unintended consequences on the Platform. Reverting per request from Andrew Odewahn.

Reverts oreillymedia/HTMLBook#223