### PR TITLE
TOOLSREQ-6431: Add Support for xrefs to Admonitions 

### DIFF
--- a/htmlbook-xsl/param.xsl
+++ b/htmlbook-xsl/param.xsl
@@ -223,6 +223,9 @@ sidebar
 refsect1
 refsect2
 refentry
+note
+tip
+warning
 </xsl:param>
 
   <!-- Params for handling of comments in a manuscript -->

--- a/htmlbook-xsl/xrefgen.xsl
+++ b/htmlbook-xsl/xrefgen.xsl
@@ -245,6 +245,28 @@
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
+
+<!-- Special xref-to handling for admonitions (notes, tips, and warnings) -->
+  <xsl:template match="h:div[contains(@data-type, 'note') or contains(@data-type, 'tip') or contains(@data-type, 'warning')]" mode="xref-to">
+    <xsl:choose>
+      <xsl:when test="h:h1[1]">
+  <!-- Choose the first descendant, h1 element, if one exists, drop in text-->
+    <xsl:text>“</xsl:text><xsl:value-of select="h:h1[1]"/><xsl:text>”</xsl:text>
+      </xsl:when>
+      <xsl:otherwise>
+  <!-- Otherwise, throw warning, and print out ??? -->
+  <xsl:call-template name="log-message">
+    <xsl:with-param name="type" select="'WARNING'"/>
+    <xsl:with-param name="message">
+      <xsl:text>Cannot output gentext for XREF to Admonition (id:</xsl:text>
+      <xsl:value-of select="@id"/>
+      <xsl:text>) that does not contain a descendant h1 element</xsl:text>
+    </xsl:with-param>
+  </xsl:call-template>
+  <xsl:text>???</xsl:text>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
   
   <!-- ADDING HANDLING FOR XREFS TO EQUATION -->
   <!-- Adapted from docbook-xsl templates in xhtml/xref.xsl -->

--- a/htmlbook-xsl/xspec/xrefgen.xspec
+++ b/htmlbook-xsl/xspec/xrefgen.xspec
@@ -1657,5 +1657,114 @@ and the script from https://github.com/xspec/xspec.">
     </x:call>
     <x:expect label="Trimmed URL should be returned as is">oreilly.com</x:expect>
   </x:scenario>
-  
+
+<!-- TOOLSREQ-6431 XREFS for Admonitions begins -->
+  <x:scenario label="When an XREF points to an admonition with a title">
+    <x:context>
+        <section data-type="chapter">
+        <div data-type="note" id="note_admonition">
+          <h1>I am a note title!</h1>
+          <p>This is a note</p>
+        </div>
+          <div data-type="tip" id="tip_admonition">
+          <h1>I am a tip title!</h1>
+          <p>This is a tip</p>
+        </div>
+        <div data-type="warning" id="warning_admonition">
+          <h1>I am a warning title!</h1>
+          <p>This is a warning</p>
+        </div>
+  </section>
+</x:context>
+
+  <x:scenario label="When an XREF points to a note with a title">
+  <x:context mode="xref-to" select="(//h:div[@data-type='note'])[1]"/>
+    <x:expect label="Gentext should be created for the xref">“I am a note title!”</x:expect>
+  </x:scenario>
+    <x:scenario label="When an XREF points to a tip with a title">
+  <x:context mode="xref-to" select="(//h:div[@data-type='tip'])[1]"/>
+    <x:expect label="Gentext should be created for the xref">“I am a tip title!”</x:expect>
+  </x:scenario>
+
+  <x:scenario label="When an XREF points to a warning with a title">
+  <x:context mode="xref-to" select="(//h:div[@data-type='warning'])[1]"/>
+    <x:expect label="Gentext should not be created for the xref">“I am a warning title!”</x:expect>
+  </x:scenario>
+ </x:scenario>
+
+<x:scenario label="When an XREF points to an admonition without a title">
+  <x:context>
+    <section data-type="chapter">
+        <div data-type="note" id="note_admonition">
+          <p>This is a note</p>
+        </div>
+        <div data-type="tip" id="tip_admonition">
+          <p>This is a tip</p>
+        </div>
+        <div data-type="warning" id="warning_admonition">
+          <p>This is a warning</p>
+        </div>
+  </section>
+  </x:context>
+
+    <x:scenario label="When an XREF points to a note without a title">
+  <x:context mode="xref-to" select="(//h:div[@data-type='note'])[1]"/>
+    <x:expect label="Gentext should not be created for the xref">???</x:expect>
+  </x:scenario>
+
+  <x:scenario label="When an XREF points to a tip without a title">
+  <x:context mode="xref-to" select="(//h:div[@data-type='tip'])[1]"/>
+    <x:expect label="Gentext should be created for the xref">???</x:expect>
+  </x:scenario>
+
+  <x:scenario label="When an XREF points to a warning without a title">
+  <x:context mode="xref-to" select="(//h:div[@data-type='warning'])[1]"/>
+    <x:expect label="Gentext should not be created for the xref">???</x:expect>
+  </x:scenario>
+</x:scenario>
+
+  <x:scenario label="When an XREF points to any admonition">
+  <x:context>
+  <x:param name="xref.elements.pagenum.in.class">
+    note
+    tip
+    warning
+  </x:param>
+  <section data-type="chapter">
+    <p>XREF to Note: <a data-type="xref" href="#note1"/></p>
+
+    <p>XREF to Tip: <a data-type="xref" href="#tip1"/></p>
+
+    <p>XREF to Warning: <a data-type="xref" href="#warning1"/></p>
+
+        <div data-type="note" id="note1">
+          <h1>I am a title!</h1>
+          <p>This is a note</p>
+        </div>
+
+        <div data-type="tip" id="tip1">
+          <h1>I am a title!</h1>
+          <p>This is a tip</p>
+        </div>
+
+        <div data-type="warning" id="warning1">
+          <h1>I am a title!</h1>
+          <p>This is a warning</p>
+        </div>
+  </section>
+  </x:context>
+   <x:scenario label="When an XREF points to any Note">
+    <x:context select="(//h:a[@data-type='xref'])[1]"/>
+    <x:expect label="The xref should generate with a pagenum class"><a href="..." data-type="xref" data-xref-pagenum-style="..." class="pagenum">...</a></x:expect>
+   </x:scenario>
+   <x:scenario label="When an XREF points to any Tip">
+    <x:context select="(//h:a[@data-type='xref'])[2]"/>
+    <x:expect label="The xref should generate with a pagenum class"><a href="..." data-type="xref" data-xref-pagenum-style="..." class="pagenum">...</a></x:expect>
+   </x:scenario>
+   <x:scenario label="When an XREF points to any Warning">
+    <x:context select="(//h:a[@data-type='xref'])[3]"/>
+    <x:expect label="The xref should generate with a pagenum class"><a href="..." data-type="xref" data-xref-pagenum-style="..." class="pagenum">...</a></x:expect>
+   </x:scenario>
+  </x:scenario>
+  <!-- TOOLSREQ-6431 ends -->
 </x:description>

--- a/htmlbook-xsl/xspec/xrefgen.xspec
+++ b/htmlbook-xsl/xspec/xrefgen.xspec
@@ -1658,7 +1658,7 @@ and the script from https://github.com/xspec/xspec.">
     <x:expect label="Trimmed URL should be returned as is">oreilly.com</x:expect>
   </x:scenario>
 
-<!-- TOOLSREQ-6431 XREFS for Admonitions begins -->
+<!-- XREFS for Admonitions begins -->
   <x:scenario label="When an XREF points to an admonition with a title">
     <x:context>
         <section data-type="chapter">


### PR DESCRIPTION
NOTE: This seems to work in practice but two xspec tests are not working. Creating a draft PR so I don't forget, but this is not ready for review.

Adding support for cross-references to admonitions (notes, tips, warnings) by
1) Giving them the pagenum class in param.xsl so that xrefs in PDFs display
the page number (as dictated by the CSS theme), and 2) adding handling in
xrefgen.xsl so that a warning is display if the linked admonition has no
title. This is necessary because admonitions are valid with and without
titles.

I branched this off of master and it looks like the staging/master commit history diverged during our last rollback. Not sure what to do about that (if anything). As mentioned above, the relevant files for the diff are param.xsl and xrefgen.xsl.

Priority: Low - Kristen mentioned that these references are rare and we have the one off in case it's necessary.

See [TOOLSREQ-6431](https://intranet.oreilly.com/jira/browse/TOOLSREQ-6431)