### PR TITLE
TOOLSREQ-6840: Adding Title Attribute to <reference> Element in content.opf

### DIFF
--- a/htmlbook-xsl/opf.xsl
+++ b/htmlbook-xsl/opf.xsl
@@ -454,7 +454,7 @@
 	  </xsl:otherwise>
 	</xsl:choose>
       </xsl:variable>
-      <reference href="{$start-of-text-filename}" type="text"/>      
+      <reference href="{$start-of-text-filename}" type="text" title="Title Page"/>      
     </guide>
   </xsl:template>
 

--- a/htmlbook-xsl/opf.xsl
+++ b/htmlbook-xsl/opf.xsl
@@ -454,7 +454,7 @@
 	  </xsl:otherwise>
 	</xsl:choose>
       </xsl:variable>
-      <reference href="{$start-of-text-filename}" type="text" title="Title Page"/>      
+      <reference href="{$start-of-text-filename}" type="text" title="Start of Text"/>      
     </guide>
   </xsl:template>
 


### PR DESCRIPTION
When testing whether Amazon will ingest our epubs, we've been
receiving errors that state: "Guide title is empty. Item is ignored"
and "This index is empty and has been skipped". I was able to locate the
source of this error in the content.opf file, which is created by opf.xsl.

In content.opf, there is a <guide> element, which contains <reference>
elements as children. There is a <reference> for the Cover, TOC, and
Title Page. The <reference>s for the Cover and TOC each have 3 attributes:
href, type, and title, while the <reference> for the Title Page only has
the first two.

Looking at the logic within opf.xsl, this seems to be because the Title Page
<reference> is set up to be flexible if there is no Title Page within the
book, and so we didn't want to hardcode a title attribute. However, given
that this is preventing ingestion to Amazon as well as the fact that every
O'Reilly title built in Atlas has a title page, I believe it is worth it
to hardcode this attribute.

Note that I'm planning on writing up an XSpec test for this, but given the relative urgency to begin testing, I wanted to get the PR up as soon as possible.

EDIT: I also wasn't sure if this would fit better under the ATLAS JIRA board better. I can move the ticket if need be.