### PR TITLE
TOOLSREQ-6840: Removing TOC from Guide

### DIFF
--- a/htmlbook-xsl/opf.xsl
+++ b/htmlbook-xsl/opf.xsl
@@ -421,16 +421,6 @@
       <xsl:if test="$generate.cover.html = 1">
 	<reference href="{$cover.html.filename}" type="cover" title="Cover"/>
       </xsl:if>
-
-      <!-- Generate reference to HTML5 TOC (EPUB Nav Doc) if present (and it should be!)-->
-      <xsl:if test="$html5.toc.node">
-	<xsl:variable name="html5-toc-filename">
-	  <xsl:call-template name="output-filename-for-chunk">
-	    <xsl:with-param name="node" select="$html5.toc.node"/>
-	  </xsl:call-template>
-	</xsl:variable>
-	<reference href="{$html5-toc-filename}" type="toc" title="Table of Contents"/>
-      </xsl:if>
       
       <!-- Calculate <reference element for start-of-text -->
       <!-- Override and customize for different handling, if desired -->


### PR DESCRIPTION
For an unknown reason, the link to the TOC in the <guide> element is causing an error when Amazon attempts to ingest our EPUBs. Rather than remove the <guide> element entirely, we decided to remove just the TOC item to preserve some of the functionality while still allowing us to send EPUBs to Amazon.

Note that this is the same branch as the [previous PR](https://github.com/oreillymedia/HTMLBook/pull/235) so as to make it easier to merge into master when the time comes.