### PR TITLE
TOOLSREQ-6840: Updating opf.xsl to Fix Amazon EPUB Ingestion Errors

### DIFF
--- a/htmlbook-xsl/opf.xsl
+++ b/htmlbook-xsl/opf.xsl
@@ -421,16 +421,6 @@
       <xsl:if test="$generate.cover.html = 1">
 	<reference href="{$cover.html.filename}" type="cover" title="Cover"/>
       </xsl:if>
-
-      <!-- Generate reference to HTML5 TOC (EPUB Nav Doc) if present (and it should be!)-->
-      <xsl:if test="$html5.toc.node">
-	<xsl:variable name="html5-toc-filename">
-	  <xsl:call-template name="output-filename-for-chunk">
-	    <xsl:with-param name="node" select="$html5.toc.node"/>
-	  </xsl:call-template>
-	</xsl:variable>
-	<reference href="{$html5-toc-filename}" type="toc" title="Table of Contents"/>
-      </xsl:if>
       
       <!-- Calculate <reference element for start-of-text -->
       <!-- Override and customize for different handling, if desired -->

--- a/htmlbook-xsl/opf.xsl
+++ b/htmlbook-xsl/opf.xsl
@@ -454,7 +454,7 @@
 	  </xsl:otherwise>
 	</xsl:choose>
       </xsl:variable>
-      <reference href="{$start-of-text-filename}" type="text"/>      
+      <reference href="{$start-of-text-filename}" type="text" title="Title Page"/>      
     </guide>
   </xsl:template>
 

--- a/htmlbook-xsl/opf.xsl
+++ b/htmlbook-xsl/opf.xsl
@@ -454,7 +454,7 @@
 	  </xsl:otherwise>
 	</xsl:choose>
       </xsl:variable>
-      <reference href="{$start-of-text-filename}" type="text" title="Title Page"/>      
+      <reference href="{$start-of-text-filename}" type="text" title="Start of Text"/>      
     </guide>
   </xsl:template>
 

--- a/htmlbook-xsl/xspec/opf.xspec
+++ b/htmlbook-xsl/xspec/opf.xspec
@@ -544,7 +544,9 @@ and the script from https://github.com/xspec/xspec.">
       <!-- Note, we can't access document context from a named template, so we can't check hrefs here, but at least we can check for existence of elements -->
       <!-- ToDo: parameterize context node for generate-guide so hrefs can be tested, and pending tests can be filled in -->
       <x:expect label="There should be a reference element for the cover if generate.cover.html is enabled" test="exists(/opf:guide/opf:reference[@type='cover'])"/>
-      <x:expect label="There should be a reference element to the EPUB Nav doc" test="exists(/opf:guide/opf:reference[@type='toc'])"/>
+      <!-- Note, we are no longer including the TOC element because of an error when sending EPUB to Amazon -->
+      <x:expect label="There *should not* be a reference element to the EPUB Nav doc" test="not(exists(/opf:guide/opf:reference[@type='toc']))"/>
+      <x:expect label="There should be a title element in the start of text reference" test="exists(/opf:guide/opf:reference[contains(@type='text' and @title='Start of Text')])"/>
       <x:scenario label="With generate.cover.html disabled">
 	<x:call>
 	  <x:param name="generate.cover.html"/>


### PR DESCRIPTION
When testing whether Amazon will ingest our epubs, we've been receiving errors that state:

- "Guide title is empty. Item is ignored"
- "This index is empty and has been skipped"
- "Hyperlink not resolved: OEBPS/toc01.html"
- "Some hyperlinks could not be resolved."

I was able to locate the source of these errors in the content.opf file, which is created by opf.xsl. All 4 errors relate to the `<guide>` element, which is created by the `generate-guide` template. The `<guide>` element contains `<reference>` elements as children. There is a `<reference>` for the Cover, TOC, and Title Page. The `<reference>`s for the Cover and TOC each have 3 attributes: href, type, and title, while the `<reference>` for the Title Page only has the first two. The `<guide>` element is an EPUB2 navigation standard that we include for backward-compatibility with older e-readers.

To fix the first two errors, I added a `title="Start of Text"`. To fix the second two errors I removed the template that creates the `<reference>` link to the TOC.

I also updated _opf.xspec_ to match the changes. Unfortunately, when we were previously reviewing the HTMLBook test suite, we were unable to get many of the XSPEC tests working, including the one that tests  `generate-guide`. XSPEC is not commonly used and we weren't able to find much help online, so we decided to mark test that errored out as `pending`. However, I wanted to make sure that if in the future that changed that the `generate-guide` test was up-to-date. XSPEC is also relatively human-readble, so the pass/fail states should be clear even without being able to run the test.