### PR TITLE
TOOLSREQ-7235: xref-number-and-title Format Change

### DIFF
--- a/htmlbook-xsl/localizations/en.xml
+++ b/htmlbook-xsl/localizations/en.xml
@@ -511,13 +511,13 @@
 <l:template name="section" text="Section %n"/>
 <l:template name="table" text="Table %n"/>
 </l:context>
-<l:context name="xref-number-and-title"><l:template name="appendix" text="Appendix %n, %t"/>
+<l:context name="xref-number-and-title"><l:template name="appendix" text="Appendix %n, “%t“"/>
 <l:template name="bridgehead" text="Section %n, “%t”"/>
-<l:template name="chapter" text="Chapter %n, %t"/>
+<l:template name="chapter" text="Chapter %n, “%t”"/>
 <l:template name="equation" text="Equation %n, “%t”"/>
 <l:template name="example" text="Example %n, “%t”"/>
 <l:template name="figure" text="Figure %n, “%t”"/>
-<l:template name="part" text="Part %n, %t"/>
+<l:template name="part" text="Part %n, “%t”"/>
 <l:template name="procedure" text="Procedure %n, “%t”"/>
 <l:template name="productionset" text="Production %n, “%t”"/>
 <l:template name="qandadiv" text="Q &amp; A %n, “%t”"/>

--- a/htmlbook-xsl/xrefgen.xsl
+++ b/htmlbook-xsl/xrefgen.xsl
@@ -608,23 +608,6 @@
 
 </xsl:template>
 
-  <xsl:template match="h:section[contains(@data-type, 'chapter') or contains(@data-type, 'appendix')] | h:div[contains(@data-type, 'part')]" mode="insert.title.markup">
-  <xsl:param name="purpose"/>
-  <xsl:param name="xrefstyle"/>
-  <xsl:param name="title"/>
-
-  <xsl:choose>
-    <xsl:when test="$purpose = 'xref'">
-      <em xmlns:xslo="http://www.w3.org/1999/XSL/Transform">
-        <xsl:copy-of select="$title"/>
-      </em>
-    </xsl:when>
-    <xsl:otherwise>
-      <xsl:copy-of select="$title"/>
-    </xsl:otherwise>
-  </xsl:choose>
-</xsl:template>
-
 <!-- ============================================================ -->
 
 <!-- Adapted from docbook-xsl common/l10.xsl stylesheet -->

--- a/htmlbook-xsl/xspec/xrefgen.xspec
+++ b/htmlbook-xsl/xspec/xrefgen.xspec
@@ -1419,21 +1419,21 @@ and the script from https://github.com/xspec/xspec.">
 We were using the Saxon JAR file version SAXON HE 9.5.1.2
 and the script from https://github.com/xspec/xspec.">
       <x:context select="//h:a[@id='chap-num-title-xref']"/>
-      <x:expect label="it should return chapter label, number, and title"><a href="#awesome_chap" id="chap-num-title-xref" data-type="xref" data-xrefstyle="chap-num-title" data-xref-pagenum-style="...">Chapter&#xa0;1, <em>AWESOME CHAPTER</em></a></x:expect>
+      <x:expect label="it should return chapter label, number, and title"><a href="#awesome_chap" id="chap-num-title-xref" data-type="xref" data-xrefstyle="chap-num-title" data-xref-pagenum-style="...">Chapter&#xa0;1, “AWESOME CHAPTER“</a></x:expect>
     </x:scenario>
 
     <x:scenario label="of 'app-num-title'" pending="We received an  error when trying to run this scenario.
 We were using the Saxon JAR file version SAXON HE 9.5.1.2
 and the script from https://github.com/xspec/xspec.">
       <x:context select="//h:a[@id='app-num-title-xref']"/>
-      <x:expect label="it should return appendix label, number, and title"><a href="#awesome_app" id="app-num-title-xref" data-type="xref" data-xrefstyle="app-num-title" data-xref-pagenum-style="...">Appendix&#xa0;A, <em>Appendix Title</em></a></x:expect>
+      <x:expect label="it should return appendix label, number, and title"><a href="#awesome_app" id="app-num-title-xref" data-type="xref" data-xrefstyle="app-num-title" data-xref-pagenum-style="...">Appendix&#xa0;A, “Appendix Title“</a></x:expect>
     </x:scenario>
 
     <x:scenario label="of 'part-num-title'" pending="We received an  error when trying to run this scenario.
 We were using the Saxon JAR file version SAXON HE 9.5.1.2
 and the script from https://github.com/xspec/xspec.">
       <x:context select="//h:a[@id='part-num-title-xref']"/>
-      <x:expect label="it should return part label, number, and title"><a href="#awesome_part" id="part-num-title-xref" data-type="xref" data-xrefstyle="part-num-title" data-xref-pagenum-style="...">Part&#xa0;I, <em>I'm Part of the Solution!</em></a></x:expect>
+      <x:expect label="it should return part label, number, and title"><a href="#awesome_part" id="part-num-title-xref" data-type="xref" data-xrefstyle="part-num-title" data-xref-pagenum-style="...">Part&#xa0;I, “I'm Part of the Solution!“</a></x:expect>
     </x:scenario>
 
     <x:scenario label="of 'select:nopage'" pending="We received an  error when trying to run this scenario.


### PR DESCRIPTION
To better conform with the Chicago Manual of Style, Production has requested we change the way we style the titles generated by cross-references to Appendixes, Chapters, and Parts. Previously they were italicized:

Appendix A, _Example Appendix Title_
Chapter 1, _Example Chapter Title_
Part I, _Example Part Title_

This PR changes them to be normal font surrounding by quotation marks:

Appendix A, “Example Appendix Title”
Chapter 1, “Example Chapter Title”
Part I, “Example Part Title”

There are three files changes, _xrefgen.xsl_ was changed to remove the template that added the italics. _localizations/en.xml_ was changed to add the quotation marks, and _xspec/xrefgen.xspec_ was changed to update a test to match the new format (note that this test is not currently working for other reasons). More details are in each commit.

Ticket: [TOOLSREQ-7235](https://intranet.oreilly.com/jira/browse/TOOLSREQ-7235)