### PR TITLE
Adding the Author Bio to the TOC

### DIFF
--- a/htmlbook-xsl/tocgen.xsl
+++ b/htmlbook-xsl/tocgen.xsl
@@ -23,9 +23,11 @@
   <xsl:template match="h:section[@data-type = 'dedication' or 
 		                 @data-type = 'titlepage' or 
 				 @data-type = 'toc' or 
-				 @data-type = 'colophon' or 
 				 @data-type = 'copyright-page' or 
 				 @data-type = 'halftitlepage']" mode="tocgen"/>
+
+  <!-- Exclude regular colophon but not author bio from TOC generation -->
+	<xsl:template match="h:section[contains(@data-type, 'colophon') and not(contains(@class, 'abouttheauthor'))]" mode="tocgen"/>
 
   <xsl:template match="h:section|h:div[@data-type='part']" mode="tocgen">
     <xsl:param name="toc.section.depth" select="$toc.section.depth"/>


### PR DESCRIPTION
This commit updates the logic of the XSL that generates the TOC to
include the author bio in the TOC. This is done by changing the
line excluding colophons to only exclude colophons if they do not
contain the class abouttheauthor (this is standard for our boilerplate).

This request comes from Kristen and is based on author complaints of 
how the Author Bio displays on the UCV on the Platform.

Note that I think we should do more QA than normal for this. I'll work with
Kristen on setting that up before we deploy to Prod.

https://intranet.oreilly.com/jira/browse/TOOLSREQ-7334