### PR TITLE
Fixing Incorrect Closing Quote Character

### DIFF
--- a/htmlbook-xsl/localizations/en.xml
+++ b/htmlbook-xsl/localizations/en.xml
@@ -511,7 +511,7 @@
 <l:template name="section" text="Section %n"/>
 <l:template name="table" text="Table %n"/>
 </l:context>
-<l:context name="xref-number-and-title"><l:template name="appendix" text="Appendix %n, “%t“"/>
+<l:context name="xref-number-and-title"><l:template name="appendix" text="Appendix %n, “%t”"/>
 <l:template name="bridgehead" text="Section %n, “%t”"/>
 <l:template name="chapter" text="Chapter %n, “%t”"/>
 <l:template name="equation" text="Equation %n, “%t”"/>


### PR DESCRIPTION
When I changed the xref style, I accidentally used two open quote characters instead of a closing quote for xrefs to the Appendix. This PR is fixing that bug.


Original JIRA ticket: https://intranet.oreilly.com/jira/browse/TOOLSREQ-7235