### PR TITLE
Adding the Author Bio to the TOC

### DIFF
--- a/htmlbook-xsl/tocgen.xsl
+++ b/htmlbook-xsl/tocgen.xsl
@@ -23,9 +23,11 @@
   <xsl:template match="h:section[@data-type = 'dedication' or 
 		                 @data-type = 'titlepage' or 
 				 @data-type = 'toc' or 
-				 @data-type = 'colophon' or 
 				 @data-type = 'copyright-page' or 
 				 @data-type = 'halftitlepage']" mode="tocgen"/>
+
+  <!-- Exclude regular colophon but not author bio from TOC generation -->
+	<xsl:template match="h:section[contains(@data-type, 'colophon') and not(contains(@class, 'abouttheauthor'))]" mode="tocgen"/>
 
   <xsl:template match="h:section|h:div[@data-type='part']" mode="tocgen">
     <xsl:param name="toc.section.depth" select="$toc.section.depth"/>

--- a/htmlbook-xsl/xspec/tocgen.xspec
+++ b/htmlbook-xsl/xspec/tocgen.xspec
@@ -235,8 +235,34 @@ and the script from https://github.com/xspec/xspec.">
     </x:context>
     <x:expect label="An entry 'li' *should not* be generated" select="()"/>
   </x:scenario>
+
+    <x:scenario label="When an abouttheauthor colophon is matched in tocgen mode">
+    <x:context select="(//h:section[@data-type='colophon'])[1]" mode="tocgen">>
+      <x:param name="toc.section.depth" select="3"/>
+      <body data-type="book">
+        <section data-type="chapter">
+          <h1>First chapter</h1>
+          <section data-type="sect1">
+            <h1>First sect1</h1>
+            <p>A paragraph</p>
+          </section>
+        </section>
+        <section data-type="chapter">
+          <h1>Second chapter</h1>
+          <p>A paragraph</p>
+        </section>
+        <section data-type="colophon" class="abouttheauthor">
+          <h1>About the Author</h1>
+          <p>There should be an entry for this in the TOC</p>
+        </section>
+      </body>
+    </x:context>
+    <x:expect label="An entry 'li' should be generated">
+      <li data-type="colophon"><a href="...">...</a></li>
+    </x:expect>
+  </x:scenario>
   
-  <x:scenario label="When a frontmatter or backmatter section is matched in tocgen mode">
+  <x:scenario label="When a standard colophon is matched in tocgen mode">
     <x:context select="(//h:section[@data-type='colophon'])[1]" mode="tocgen">>
       <x:param name="toc.section.depth" select="3"/>
       <body data-type="book">
@@ -252,7 +278,7 @@ and the script from https://github.com/xspec/xspec.">
           <p>A paragraph</p>
         </section>
         <section data-type="colophon">
-          <h1>About the Author</h1>
+          <h1>Colophon</h1>
           <p>There shouldn't be an entry for this in the TOC</p>
         </section>
       </body>


### PR DESCRIPTION
This PR updates the logic of the XSL that generates the TOC to
include the author bio in the TOC. This is done by changing the
line excluding colophons to only exclude colophons if they do not
contain the class abouttheauthor (this is standard for our boilerplate).

It also updates our XSpec testing suite to match the new behavior.

This request comes from Kristen and is based on author complaints of 
how the Author Bio displays on the UCV on the Platform.

https://intranet.oreilly.com/jira/browse/TOOLSREQ-7334

Re-requesting a review because I added the XSpec commit and the time elapsed since the [earlier PR](https://github.com/oreillymedia/HTMLBook/pull/240).