### PR TITLE
Toolsdev 389 accessibility summary

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# These owners will be the default owners for everything in
+# the repo.
+*       @oreillymedia/tools-team

--- a/htmlbook-xsl/opf.xsl
+++ b/htmlbook-xsl/opf.xsl
@@ -493,6 +493,11 @@
     <xsl:for-each select="exsl:node-set($accessibility.hazards.list.xml)//e:hazard">
       <meta property="schema:accessibilityHazard"><xsl:value-of select="."/></meta>
     </xsl:for-each>
+
+    <!-- Generate schema:accessibilitySummary element if summary is provided -->
+    <xsl:if test="$accessibility.summary != ''">
+      <meta property="schema:accessibilitySummary"><xsl:value-of select="$accessibility.summary"/></meta>
+    </xsl:if>
     </metadata>
   </xsl:template>
 


### PR DESCRIPTION
Adds the XSL to apply the `accessibilitySummary` property, nothing that if it's not provided by the epubrenderer, it will fail (again prompting the discussion about if/how we should pull this into that repo).