### PR TITLE
Toolsdev 389 accessibility summary

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# These owners will be the default owners for everything in
+# the repo.
+*       @oreillymedia/tools-team

--- a/htmlbook-xsl/opf.xsl
+++ b/htmlbook-xsl/opf.xsl
@@ -493,6 +493,11 @@
     <xsl:for-each select="exsl:node-set($accessibility.hazards.list.xml)//e:hazard">
       <meta property="schema:accessibilityHazard"><xsl:value-of select="."/></meta>
     </xsl:for-each>
+
+    <!-- Generate schema:accessibilitySummary element if summary is provided -->
+    <xsl:if test="$accessibility.summary != ''">
+      <meta property="schema:accessibilitySummary"><xsl:value-of select="$accessibility.summary"/></meta>
+    </xsl:if>
     </metadata>
   </xsl:template>
 


### PR DESCRIPTION
Verified on staging:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<package xmlns="http://www.idpf.org/2007/opf" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" version="3.0" unique-identifier="pub-identifier" prefix="ibooks: http://vocabulary.itunes.apple.com/rdf/ibooks/vocabulary-extensions-1.0/">
    <metadata>
        <dc:identifier id="pub-identifier">
            9781492056355
        </dc:identifier>
        <meta id="meta-identifier" property="dcterms:identifier">
            9781492056355
        </meta>
        <dc:title id="pub-title">
            Fluent Python
        </dc:title>
        <meta property="dcterms:title" id="meta-title">
            Fluent Python
        </meta>
 <!-- snip -->
        <meta property="schema:accessibilitySummary">
            While some O&amp;#x2019;Reilly content may include additional
            accessibility features, all of our content supports language tagging
            and structural, landmark, and index navigation. No accessibility
            features are actively disabled.
        </meta>
    </metadata>
```