### PR TITLE
TOOLSDEV-539: add xml and html lang declarations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Mac Finder files
 .DS_Store
+
+# test artifacts
+htmlbook-xsl/xspec/xspec/ 

--- a/htmlbook-xsl/chunk.xsl
+++ b/htmlbook-xsl/chunk.xsl
@@ -243,7 +243,7 @@ sect5:s
       </xsl:when>
       <!-- Otherwise, go ahead and do the following default chunk processing -->
       <xsl:when test="not(self::h:html)">
-	<html>
+	<html lang="{$book-language}" xml:lang="{$book-language}">
 	  <!-- ToDo: What else do we want in the <head>? -->
 	  <head>
 	    <title>

--- a/htmlbook-xsl/epub.xsl
+++ b/htmlbook-xsl/epub.xsl
@@ -323,7 +323,7 @@ UbuntuMono-Italic.otf</xsl:param>
     <!-- Only add the <html>/<head> if they don't already exist -->
     <xsl:choose>
       <xsl:when test="not(self::h:html)">
-	<html xmlns:epub="http://www.idpf.org/2007/ops">
+	<html xmlns:epub="http://www.idpf.org/2007/ops" lang="{$book-language}" xml:lang="{$book-language}">
 	  <!-- ToDo: What else do we want in the <head>? -->
 	  <head>
 	    <title>

--- a/htmlbook-xsl/htmlbook.xsl
+++ b/htmlbook-xsl/htmlbook.xsl
@@ -89,4 +89,20 @@
     </xsl:copy>
   </xsl:template>
 
-</xsl:stylesheet> 
+  <!-- Ensure the root <html> element in single-file output carries both
+       lang and xml:lang, with matching values taken from $book-language.
+       $book-language defaults to the source @lang but can be overridden
+       by the caller; the override is authoritative. -->
+  <xsl:template match="h:html">
+    <xsl:copy>
+      <xsl:attribute name="lang">
+        <xsl:value-of select="$book-language"/>
+      </xsl:attribute>
+      <xsl:attribute name="xml:lang">
+        <xsl:value-of select="$book-language"/>
+      </xsl:attribute>
+      <xsl:apply-templates select="@*[local-name() != 'lang' or (namespace-uri() != '' and namespace-uri() != 'http://www.w3.org/XML/1998/namespace')]|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/htmlbook-xsl/opf.xsl
+++ b/htmlbook-xsl/opf.xsl
@@ -243,7 +243,7 @@
 
   <xsl:template name="generate.opf.content">
     <xsl:param name="generate.guide" select="$generate.guide"/>
-    <package version="3.0" unique-identifier="{$metadata.unique-identifier.id}">
+    <package version="3.0" unique-identifier="{$metadata.unique-identifier.id}" xml:lang="{$book-language}">
       <xsl:if test="$metadata.ibooks-specified-fonts = 1">
 	<xsl:attribute name="prefix">
 	  <xsl:text>ibooks: http://vocabulary.itunes.apple.com/rdf/ibooks/vocabulary-extensions-1.0/</xsl:text>

--- a/htmlbook-xsl/xspec/lang-declarations-chunk-driver.xsl
+++ b/htmlbook-xsl/xspec/lang-declarations-chunk-driver.xsl
@@ -1,0 +1,23 @@
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:h="http://www.w3.org/1999/xhtml"
+                xmlns:t="https://github.com/oreillymedia/HTMLBook/xspec-test"
+                xmlns="http://www.w3.org/1999/xhtml"
+                exclude-result-prefixes="h t">
+
+  <!-- Test driver for lang-declarations-chunk.xspec. Imports chunk.xsl
+       (not epub.xsl) so the tests exercise chunk.xsl's own
+       process-content-for-chunk, which does not declare the epub
+       namespace. Sidesteps the same xspec 0.4 <x:call>+<x:context>
+       compiler bug worked around in lang-declarations-epub-driver.xsl.
+       Remove this file when these tests move into chunk.xspec. -->
+
+  <xsl:import href="../chunk.xsl"/>
+
+  <xsl:output method="xml" encoding="UTF-8"/>
+
+  <xsl:template match="t:chunk-trigger">
+    <xsl:call-template name="process-content-for-chunk"/>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/htmlbook-xsl/xspec/lang-declarations-chunk.xspec
+++ b/htmlbook-xsl/xspec/lang-declarations-chunk.xspec
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               xmlns="http://www.w3.org/1999/xhtml"
+               xmlns:h="http://www.w3.org/1999/xhtml"
+               xmlns:t="https://github.com/oreillymedia/HTMLBook/xspec-test"
+               stylesheet="lang-declarations-chunk-driver.xsl">
+
+  <!-- TEMPORARY test suite (TOOLSDEV-539): covers the lang/xml:lang
+       attributes emitted by process-content-for-chunk in chunk.xsl for
+       chunked HTML output (distinct from epub.xsl, which has its own
+       higher-precedence override of the same template). Once the
+       xspec-compiler bug and opf.xsl param bug are fixed, these scenarios
+       should be folded into chunk.xspec and the driver deleted. -->
+
+  <!-- Non-default tag so a hard-coded default would be caught. -->
+  <x:param name="book-language" select="'es'"/>
+
+  <x:scenario label="When process-content-for-chunk wraps a non-html node">
+    <x:context select="(//t:chunk-trigger)[1]">
+      <t:chunk-trigger/>
+    </x:context>
+    <x:expect label="generated html carries lang"
+              test="/h:html/@lang = 'es'"/>
+    <x:expect label="generated html carries xml:lang"
+              test="/h:html/@xml:lang = 'es'"/>
+    <x:expect label="lang and xml:lang agree"
+              test="/h:html/@lang = /h:html/@xml:lang"/>
+    <x:expect label="only one lang attribute is emitted"
+              test="count(/h:html/@lang) = 1"/>
+    <x:expect label="only one xml:lang attribute is emitted"
+              test="count(/h:html/@xml:lang) = 1"/>
+    <x:expect label="generated html does NOT declare the epub namespace"
+              test="not(namespace-uri-for-prefix('epub', /h:html))"/>
+  </x:scenario>
+
+</x:description>

--- a/htmlbook-xsl/xspec/lang-declarations-epub-driver.xsl
+++ b/htmlbook-xsl/xspec/lang-declarations-epub-driver.xsl
@@ -1,0 +1,26 @@
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:h="http://www.w3.org/1999/xhtml"
+                xmlns:t="https://github.com/oreillymedia/HTMLBook/xspec-test"
+                xmlns="http://www.w3.org/1999/xhtml"
+                exclude-result-prefixes="h t">
+
+  <!-- Test driver for lang-declarations-epub.xspec. Imports epub.xsl so
+       tests can reach its templates, and exposes process-content-for-chunk
+       via a match template on a custom element. This sidesteps a bug in
+       xspec 0.4 where <x:call> combined with <x:context> generates an
+       undeclared $context variable. Remove this file when those tests move
+       to epub.xspec. -->
+
+  <xsl:import href="../epub.xsl"/>
+
+  <xsl:output method="xml" encoding="UTF-8"/>
+
+  <!-- Match a custom trigger element and route it through
+       process-content-for-chunk. The trigger's namespace keeps it from
+       colliding with any existing match patterns in the imported chain. -->
+  <xsl:template match="t:chunk-trigger">
+    <xsl:call-template name="process-content-for-chunk"/>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/htmlbook-xsl/xspec/lang-declarations-epub.xspec
+++ b/htmlbook-xsl/xspec/lang-declarations-epub.xspec
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               xmlns="http://www.w3.org/1999/xhtml"
+               xmlns:h="http://www.w3.org/1999/xhtml"
+               xmlns:epub="http://www.idpf.org/2007/ops"
+               xmlns:t="https://github.com/oreillymedia/HTMLBook/xspec-test"
+               stylesheet="lang-declarations-epub-driver.xsl">
+
+  <!-- TEMPORARY test suite (TOOLSDEV-539): covers the lang/xml:lang
+       attributes emitted by process-content-for-chunk in epub.xsl. The
+       same pattern is used in chunk.xsl; because epub.xsl imports chunk.xsl
+       and epub.xsl's process-content-for-chunk wins by precedence, this
+       suite exercises the EPUB branch specifically (the branch that also
+       emits xmlns:epub). Once the pre-existing opf.xsl undeclared-param bug
+       is fixed, fold these scenarios into epub.xspec and chunk.xspec and
+       delete the companion driver stylesheet. -->
+
+  <!-- Workaround: opf.xsl (included by epub.xsl) references these five
+       params without declaring them, which otherwise fails compilation. -->
+  <x:param name="access.mode" select="''"/>
+  <x:param name="access.mode.sufficient" select="''"/>
+  <x:param name="accessibility.feature" select="''"/>
+  <x:param name="accessibility.hazard" select="''"/>
+  <x:param name="accessibility.summary" select="''"/>
+
+  <!-- Non-default BCP 47 tag so a hard-coded default would be caught. -->
+  <x:param name="book-language" select="'es'"/>
+
+  <x:scenario label="When process-content-for-chunk wraps a non-html node">
+    <x:context select="(//t:chunk-trigger)[1]">
+      <t:chunk-trigger/>
+    </x:context>
+    <x:expect label="generated html carries lang"
+              test="/h:html/@lang = 'es'"/>
+    <x:expect label="generated html carries xml:lang"
+              test="/h:html/@xml:lang = 'es'"/>
+    <x:expect label="lang and xml:lang agree"
+              test="/h:html/@lang = /h:html/@xml:lang"/>
+    <x:expect label="only one lang attribute is emitted"
+              test="count(/h:html/@lang) = 1"/>
+    <x:expect label="only one xml:lang attribute is emitted"
+              test="count(/h:html/@xml:lang) = 1"/>
+    <x:expect label="generated html still declares the epub namespace"
+              test="namespace-uri-for-prefix('epub', /h:html) = 'http://www.idpf.org/2007/ops'"/>
+  </x:scenario>
+
+  <!-- NOTE: xml:lang on the <package> element in content.opf (emitted by
+       generate.opf.content in opf.xsl) cannot be covered here because
+       The existing version of Saxon HE does not implement exsl:node-set(), 
+       which generate.opf.content calls at runtime. That change is verified
+       manually via xsltproc; see the branch description for the command.
+       When the wider test-suite refactor lands, move this into opf.xspec
+       where the same limitation likely needs a different processor. -->
+
+</x:description>

--- a/htmlbook-xsl/xspec/lang-declarations-htmlbook.xspec
+++ b/htmlbook-xsl/xspec/lang-declarations-htmlbook.xspec
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               xmlns="http://www.w3.org/1999/xhtml"
+               xmlns:h="http://www.w3.org/1999/xhtml"
+               stylesheet="../htmlbook.xsl">
+
+  <!-- TEMPORARY test suite (TOOLSDEV-539): covers the new h:html template in
+       htmlbook.xsl that emits lang and xml:lang on single-file HTML output.
+       Once the pre-existing opf.xsl undeclared-param bug is fixed, these
+       scenarios should be folded into elements.xspec. -->
+
+  <!-- Fix book-language globally to a non-default value; this xspec version
+       does not support per-scenario overrides. The value is chosen to be
+       distinct from the fallback 'en' and from any source @lang used in the
+       scenarios below, so that a hard-coded default would be caught. -->
+  <x:param name="book-language" select="'es'"/>
+
+  <x:scenario label="When the source html has no lang attribute">
+    <x:context select="/h:html">
+      <html>
+        <body data-type="book"><p>hello</p></body>
+      </html>
+    </x:context>
+    <x:expect label="lang is emitted with book-language value"
+              test="/h:html/@lang = 'es'"/>
+    <x:expect label="xml:lang is emitted with book-language value"
+              test="/h:html/@xml:lang = 'es'"/>
+  </x:scenario>
+
+  <x:scenario label="When the source html has a lang attribute that differs from book-language">
+    <x:context select="/h:html">
+      <html lang="fr">
+        <body data-type="book"><p>bonjour</p></body>
+      </html>
+    </x:context>
+    <x:expect label="output lang reflects book-language, not source lang"
+              test="/h:html/@lang = 'es'"/>
+    <x:expect label="output xml:lang also reflects book-language"
+              test="/h:html/@xml:lang = 'es'"/>
+    <x:expect label="only one lang attribute is emitted"
+              test="count(/h:html/@lang) = 1"/>
+  </x:scenario>
+
+  <x:scenario label="When the source html has an xml:lang attribute that differs from book-language">
+    <x:context select="/h:html">
+      <html xml:lang="de">
+        <body data-type="book"><p>hallo</p></body>
+      </html>
+    </x:context>
+    <x:expect label="output xml:lang reflects book-language, not source xml:lang"
+              test="/h:html/@xml:lang = 'es'"/>
+    <x:expect label="only one xml:lang attribute is emitted"
+              test="count(/h:html/@xml:lang) = 1"/>
+  </x:scenario>
+
+  <x:scenario label="When the source html carries unrelated attributes">
+    <x:context select="/h:html">
+      <html class="book" id="root">
+        <body data-type="book"><p>hi</p></body>
+      </html>
+    </x:context>
+    <x:expect label="class is preserved"
+              test="/h:html/@class = 'book'"/>
+    <x:expect label="id is preserved"
+              test="/h:html/@id = 'root'"/>
+  </x:scenario>
+
+</x:description>


### PR DESCRIPTION
Single-file HTML, chunked HTML, and EPUB chunk outputs now emit both lang and xml:lang on the root element, and the EPUB package document (content.opf) carries xml:lang. The attributes are driven by the existing $book-language param, so callers can override the default via --stringparam and have it flow consistently to the HTML wrappers, consistent with our handling for dc:language and dcterms:language. 

Test coverage included. Tests added in temporary discrete suites specific to the new features to sidestep some existing bugs in epub.xsl and opf.xsl that prevent their corresponding test suites from running. Comments in the new test files document where to move the tests once those issues are addressed.

Also included a commit to keep those pesky test artifacts out of our version control. 