### PR TITLE
Declare accessibility params in epub.xsl to fix xspec compilation

### DIFF
--- a/htmlbook-xsl/epub.xsl
+++ b/htmlbook-xsl/epub.xsl
@@ -141,6 +141,14 @@
 
   <xsl:param name="metadata.creators" select="//h:head/h:meta[contains(@name, 'creator') or contains(@name, 'author')]"/>
 
+  <!-- Accessibility metadata params: each accepts a newline-delimited list of values, except
+       accessibility.summary which is a plain string. Processed in opf.xsl into schema: meta elements. -->
+  <xsl:param name="access.mode" select="''"/>
+  <xsl:param name="access.mode.sufficient" select="''"/>
+  <xsl:param name="accessibility.feature" select="''"/>
+  <xsl:param name="accessibility.hazard" select="''"/>
+  <xsl:param name="accessibility.summary" select="''"/>
+
   <!-- Id to use to reference cover image -->
   <xsl:param name="epub.cover.image.id" select="'cover-image'"/>
 


### PR DESCRIPTION
opf.xsl references $access.mode, $access.mode.sufficient, $accessibility.feature, $accessibility.hazard, and $accessibility.summary, but these were never declared as <xsl:param> elements anywhere in the stylesheet hierarchy.

Saxon enforces the XSLT spec strictly and raises XPST0008 (undeclared variable) at compile time, which prevented epub.xspec, ncx.xspec, and opf.xspec from running at all. Production was unaffected because xsltproc (libxslt) accepts caller-supplied parameters even without declarations.

Adding the params to epub.xsl — alongside the other metadata params — makes the stylesheets spec-conformant and restores test compilation without changing production behavior.

Tested on Atlas staging.