### PR TITLE
TOOLSDEV-620: Add lang/xml:lang to cover HTML output

### DIFF
--- a/htmlbook-xsl/epub.xsl
+++ b/htmlbook-xsl/epub.xsl
@@ -256,22 +256,28 @@ UbuntuMono-Italic.otf</xsl:param>
     <xsl:apply-imports/>
   </xsl:template>
 
+  <!-- Produces the cover <html> document node. Extracted from generate-cover-html
+       so it can be called directly in XSpec tests (result-document output is not
+       testable via XSpec). -->
+  <xsl:template name="cover-html-document">
+    <html xmlns:epub="http://www.idpf.org/2007/ops" lang="{$book-language}" xml:lang="{$book-language}">
+      <head>
+        <title>Cover</title>
+        <xsl:if test="$css.filename != ''">
+          <link rel="stylesheet" type="text/css" href="{$css.filename}" />
+        </xsl:if>
+      </head>
+      <body>
+        <xsl:copy-of select="//h:figure[@data-type='cover'][1]"/>
+      </body>
+    </html>
+  </xsl:template>
+
   <!-- Output an HTML file for the book cover; override and customize as needed. Default output generally the same as epub3 docbook-xsl stylesheets -->
   <xsl:template name="generate-cover-html">
     <xsl:variable name="cover.html.content">
       <xsl:value-of select="'&lt;!DOCTYPE html&gt;'" disable-output-escaping="yes"/>
-      <html xmlns:epub="http://www.idpf.org/2007/ops">
-	<!-- ToDo: What else do we want in the <head>? -->
-	<head>
-	  <title>Cover</title>
-	  <xsl:if test="$css.filename != ''">
-	    <link rel="stylesheet" type="text/css" href="{$css.filename}" />
-	  </xsl:if>
-	</head>
-	<body>
-	  <xsl:copy-of select="//h:figure[@data-type='cover'][1]"/>
-	</body>
-      </html>
+      <xsl:call-template name="cover-html-document"/>
     </xsl:variable>
     <xsl:result-document href="{$full.cover.filename}" method="xml" encoding="UTF-8">
       <xsl:copy-of select="$cover.html.content"/>

--- a/htmlbook-xsl/xspec/lang-declarations-epub-driver.xsl
+++ b/htmlbook-xsl/xspec/lang-declarations-epub-driver.xsl
@@ -23,4 +23,10 @@
     <xsl:call-template name="process-content-for-chunk"/>
   </xsl:template>
 
+  <!-- Routes a cover trigger element through cover-html-document so
+       XSpec can assert on the generated <html> node. -->
+  <xsl:template match="t:cover-trigger">
+    <xsl:call-template name="cover-html-document"/>
+  </xsl:template>
+
 </xsl:stylesheet>

--- a/htmlbook-xsl/xspec/lang-declarations-epub.xspec
+++ b/htmlbook-xsl/xspec/lang-declarations-epub.xspec
@@ -45,9 +45,27 @@
               test="namespace-uri-for-prefix('epub', /h:html) = 'http://www.idpf.org/2007/ops'"/>
   </x:scenario>
 
+  <x:scenario label="When cover-html-document generates the cover HTML file">
+    <x:context select="(//t:cover-trigger)[1]">
+      <t:cover-trigger/>
+    </x:context>
+    <x:expect label="generated html carries lang"
+              test="/h:html/@lang = 'es'"/>
+    <x:expect label="generated html carries xml:lang"
+              test="/h:html/@xml:lang = 'es'"/>
+    <x:expect label="lang and xml:lang agree"
+              test="/h:html/@lang = /h:html/@xml:lang"/>
+    <x:expect label="only one lang attribute is emitted"
+              test="count(/h:html/@lang) = 1"/>
+    <x:expect label="only one xml:lang attribute is emitted"
+              test="count(/h:html/@xml:lang) = 1"/>
+    <x:expect label="generated html still declares the epub namespace"
+              test="namespace-uri-for-prefix('epub', /h:html) = 'http://www.idpf.org/2007/ops'"/>
+  </x:scenario>
+
   <!-- NOTE: xml:lang on the <package> element in content.opf (emitted by
        generate.opf.content in opf.xsl) cannot be covered here because
-       The existing version of Saxon HE does not implement exsl:node-set(), 
+       The existing version of Saxon HE does not implement exsl:node-set(),
        which generate.opf.content calls at runtime. That change is verified
        manually via xsltproc; see the branch description for the command.
        When the wider test-suite refactor lands, move this into opf.xspec


### PR DESCRIPTION
generate-cover-html was missed when process-content-for-chunk was updated in TOOLSDEV-539. Extract cover-html-document helper so the lang/xml:lang attributes are testable via XSpec, and call it from generate-cover-html.